### PR TITLE
Update `ApiComUrl` to point to correct domain.

### DIFF
--- a/travis.go
+++ b/travis.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	ApiOrgUrl = "https://api.travis-ci.org/"
-	ApiComUrl = "https://api.travis-ci.org/"
+	ApiComUrl = "https://api.travis-ci.com/"
 
 	userAgent          = "go-travis/" + version
 	defaultContentType = "application/json"


### PR DESCRIPTION
Update `ApiComUrl` to point to `https://api.travis-ci.com` instead of `https://api.travis-ci.org`