### PR TITLE
Use HTTP body as error message if JSON decoding fails

### DIFF
--- a/travis.go
+++ b/travis.go
@@ -272,7 +272,9 @@ func checkResponse(r *http.Response) error {
 
 	data, err := ioutil.ReadAll(r.Body)
 	if err == nil && data != nil {
-		json.Unmarshal(data, errorResponse)
+		if err := json.Unmarshal(data, errorResponse); err != nil {
+			errorResponse.ErrorMessage = string(data)
+		}
 	}
 
 	return errorResponse


### PR DESCRIPTION
Applies https://github.com/broady/go-travis/commit/adb88e49aab102a8864cd6f9b60aa11a9cd80450