### PR TITLE
Chenge Tag from string to struct

### DIFF
--- a/builds.go
+++ b/builds.go
@@ -51,7 +51,7 @@ type Build struct {
 	// The branch the build is associated with
 	Branch MinimalBranch `json:"branch,omitempty"`
 	// The build's tag
-	Tag string `json:"tag,omitempty"`
+	Tag MinimalTag `json:"tag,omitempty"`
 	// The commit the build is associated with
 	Commit MinimalCommit `json:"commit,omitempty"`
 	// List of jobs that are part of the build's matrix

--- a/tags.go
+++ b/tags.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2015 Ableton AG, Berlin. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package travis
+
+// MinimalTag is a minimal representation of a Travis CI tag
+type MinimalTag struct {
+	// Value uniquely identifying a repository of the build belongs to
+	RepositoryId uint `json:"repository_id"`
+	// Name of the tag
+	Name string `json:"name,omitempty"`
+	// Id of a last build on the branch
+	LastBuildId uint `json:"last_build_id"`
+	Metadata
+}


### PR DESCRIPTION
Fixes https://github.com/shuheiktgw/go-travis/issues/6.
Tag is actually not a string but a struct, which is not described on Travis CI documentation. Life is always full of challenges... 😇 