### PR TITLE
Fix to return pointer and add eager loading support for the build end…

### DIFF
--- a/active.go
+++ b/active.go
@@ -20,13 +20,13 @@ type ActiveService struct {
 // getActiveResponse represents the response of a call
 // to the Travis CI active endpoint.
 type getActiveResponse struct {
-	Builds []Build `json:"builds"`
+	Builds []*Build `json:"builds"`
 }
 
 // FindByOwner fetches active builds based on the owner's name
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/active#for_owner
-func (as *ActiveService) FindByOwner(ctx context.Context, owner string) ([]Build, *http.Response, error) {
+func (as *ActiveService) FindByOwner(ctx context.Context, owner string) ([]*Build, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/owner/%s/active", owner), nil)
 	if err != nil {
 		return nil, nil, err
@@ -49,7 +49,7 @@ func (as *ActiveService) FindByOwner(ctx context.Context, owner string) ([]Build
 // FindByGitHubId fetches active builds based on the owner's GitHub id
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/active#for_owner
-func (as *ActiveService) FindByGitHubId(ctx context.Context, githubId uint) ([]Build, *http.Response, error) {
+func (as *ActiveService) FindByGitHubId(ctx context.Context, githubId uint) ([]*Build, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/owner/github_id/%d/active", githubId), nil)
 	if err != nil {
 		return nil, nil, err

--- a/active_test.go
+++ b/active_test.go
@@ -31,7 +31,7 @@ func TestActiveService_FindByOwner(t *testing.T) {
 		t.Errorf("Active.FindByOwner returned error: %v", err)
 	}
 
-	want := []Build{{Id: testBuildId, Number: "1", State: BuildStateCreated, Duration: 10}}
+	want := []*Build{{Id: testBuildId, Number: "1", State: BuildStateCreated, Duration: 10}}
 	if !reflect.DeepEqual(builds, want) {
 		t.Errorf("Active.FindByOwner returned %+v, want %+v", builds, want)
 	}
@@ -52,7 +52,7 @@ func TestActiveService_FindByGitHubId(t *testing.T) {
 		t.Errorf("Active.FindByGitHubId returned error: %v", err)
 	}
 
-	want := []Build{{Id: testBuildId, Number: "1", State: BuildStateCreated, Duration: 10}}
+	want := []*Build{{Id: testBuildId, Number: "1", State: BuildStateCreated, Duration: 10}}
 	if !reflect.DeepEqual(builds, want) {
 		t.Errorf("Active.FindByGitHubId returned %+v, want %+v", builds, want)
 	}

--- a/beta_features.go
+++ b/beta_features.go
@@ -31,19 +31,19 @@ type BetaFeature struct {
 	Enabled bool `json:"enabled,omitempty"`
 	// Url for users to leave Travis CI feedback on this feature
 	FeedbackUrl string `json:"feedback_url,omitempty"`
-	Metadata
+	*Metadata
 }
 
 // getBetaFeaturesResponse represents a response
 // from organizations endpoints
 type getBetaFeaturesResponse struct {
-	BetaFeatures []BetaFeature `json:"beta_features,omitempty"`
+	BetaFeatures []*BetaFeature `json:"beta_features,omitempty"`
 }
 
 // List fetches a list of beta features available to a user
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/beta_features#find
-func (bs *BetaFeaturesService) List(ctx context.Context, userId uint) ([]BetaFeature, *http.Response, error) {
+func (bs *BetaFeaturesService) List(ctx context.Context, userId uint) ([]*BetaFeature, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/user/%d/beta_features", userId), nil)
 	if err != nil {
 		return nil, nil, err

--- a/beta_features_test.go
+++ b/beta_features_test.go
@@ -28,7 +28,7 @@ func TestBetaFeaturesService_List(t *testing.T) {
 		t.Errorf("BetaFeatures.List returned error: %v", err)
 	}
 
-	want := []BetaFeature{{Id: 1, Name: "dashboard", Description: "Try the new personal Dashboard layout", Enabled: true, FeedbackUrl: "https://github.com/travis-ci/beta-features/issues/5"}}
+	want := []*BetaFeature{{Id: 1, Name: "dashboard", Description: "Try the new personal Dashboard layout", Enabled: true, FeedbackUrl: "https://github.com/travis-ci/beta-features/issues/5"}}
 	if !reflect.DeepEqual(features, want) {
 		t.Errorf("BetaFeatures.List returned %+v, want %+v", features, want)
 	}

--- a/branches.go
+++ b/branches.go
@@ -25,22 +25,14 @@ type Branch struct {
 	// Name of the git branch
 	Name string `json:"name,omitempty"`
 	// GitHub Repository
-	Repository MinimalRepository `json:"repository,omitempty"`
+	Repository *Repository `json:"repository,omitempty"`
 	// Whether or not this is the repository's default branch
 	DefaultBranch bool `json:"default_branch,omitempty"`
 	// Whether or not the branch still exists on GitHub
 	ExistsOnGithub bool `json:"exists_on_github,omitempty"`
 	// Last build on the branch
-	LastBuild MinimalBuild `json:"last_build,omitempty"`
-	Metadata
-}
-
-// MinimalBranch included when the resource is returned as part of another resource
-//
-// Travis CI API docs: https://developer.travis-ci.com/resource/branch#minimal-representation
-type MinimalBranch struct {
-	// Name of the git branch
-	Name string `json:"name,omitempty"`
+	LastBuild *Build `json:"last_build,omitempty"`
+	*Metadata
 }
 
 // ListBranchesOption specifies the optional parameters for branches endpoint
@@ -58,7 +50,7 @@ type ListBranchesOption struct {
 // getBranchesResponse represents the response of a call
 // to the Travis CI branches endpoint.
 type getBranchesResponse struct {
-	Branches []Branch `json:"branches"`
+	Branches []*Branch `json:"branches"`
 }
 
 // FindByRepoId fetches a branch based on the provided repository id and branch name
@@ -110,7 +102,7 @@ func (bs *BranchesService) FindByRepoSlug(ctx context.Context, repoSlug string, 
 // ListByRepoId fetches the branches of a given repository id.
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/branches#find
-func (bs *BranchesService) ListByRepoId(ctx context.Context, repoId uint, opt *ListBranchesOption) ([]Branch, *http.Response, error) {
+func (bs *BranchesService) ListByRepoId(ctx context.Context, repoId uint, opt *ListBranchesOption) ([]*Branch, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/branches", repoId), opt)
 	if err != nil {
 		return nil, nil, err
@@ -133,7 +125,7 @@ func (bs *BranchesService) ListByRepoId(ctx context.Context, repoId uint, opt *L
 // ListByRepoSlug fetches the branches of a given repository slug.
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/branches#find
-func (bs *BranchesService) ListByRepoSlug(ctx context.Context, repoSlug string, opt *ListBranchesOption) ([]Branch, *http.Response, error) {
+func (bs *BranchesService) ListByRepoSlug(ctx context.Context, repoSlug string, opt *ListBranchesOption) ([]*Branch, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/branches", url.QueryEscape(repoSlug)), opt)
 	if err != nil {
 		return nil, nil, err

--- a/branches_test.go
+++ b/branches_test.go
@@ -35,7 +35,7 @@ func TestBranchesService_FindByRepoId(t *testing.T) {
 		t.Errorf("Branch.FindByRepoId returned error: %v", err)
 	}
 
-	want := &Branch{Name: "master", Repository: MinimalRepository{Id: 1, Name: "test", Slug: "shuheiktgw/test"}, DefaultBranch: true, ExistsOnGithub: true}
+	want := &Branch{Name: "master", Repository: &Repository{Id: 1, Name: "test", Slug: "shuheiktgw/test"}, DefaultBranch: true, ExistsOnGithub: true}
 	if !reflect.DeepEqual(branch, want) {
 		t.Errorf("Branch.FindByRepoId returned %+v, want %+v", branch, want)
 	}
@@ -56,7 +56,7 @@ func TestBranchesService_FindByRepoSlug(t *testing.T) {
 		t.Errorf("Branch.FindByRepoId returned error: %v", err)
 	}
 
-	want := &Branch{Name: "master", Repository: MinimalRepository{Id: 1, Name: "test", Slug: "shuheiktgw/test"}, DefaultBranch: true, ExistsOnGithub: true}
+	want := &Branch{Name: "master", Repository: &Repository{Id: 1, Name: "test", Slug: "shuheiktgw/test"}, DefaultBranch: true, ExistsOnGithub: true}
 	if !reflect.DeepEqual(branch, want) {
 		t.Errorf("Branch.FindByRepoId returned %+v, want %+v", branch, want)
 	}
@@ -78,7 +78,7 @@ func TestBranchesService_ListByRepoId(t *testing.T) {
 		t.Errorf("Branches.FindByRepoId returned error: %v", err)
 	}
 
-	want := []Branch{{Name: "master", Repository: MinimalRepository{Id: 1, Name: "test", Slug: "shuheiktgw/test"}, DefaultBranch: true, ExistsOnGithub: true}}
+	want := []*Branch{{Name: "master", Repository: &Repository{Id: 1, Name: "test", Slug: "shuheiktgw/test"}, DefaultBranch: true, ExistsOnGithub: true}}
 	if !reflect.DeepEqual(branches, want) {
 		t.Errorf("Branchse.FindByRepoId returned %+v, want %+v", branches, want)
 	}
@@ -100,7 +100,7 @@ func TestBranchesService_ListByRepoSlug(t *testing.T) {
 		t.Errorf("Branches.indByRepoSlug returned error: %v", err)
 	}
 
-	want := []Branch{{Name: "master", Repository: MinimalRepository{Id: 1, Name: "test", Slug: "shuheiktgw/test"}, DefaultBranch: true, ExistsOnGithub: true}}
+	want := []*Branch{{Name: "master", Repository: &Repository{Id: 1, Name: "test", Slug: "shuheiktgw/test"}, DefaultBranch: true, ExistsOnGithub: true}}
 	if !reflect.DeepEqual(branches, want) {
 		t.Errorf("Branchse.indByRepoSlug returned %+v, want %+v", branches, want)
 	}

--- a/broadcasts.go
+++ b/broadcasts.go
@@ -32,7 +32,7 @@ type Broadcast struct {
 	CreatedAt string `json:"created_at,omitempty"`
 	// Either a user, organization or repository, or null for global
 	Recipient interface{} `json:"recipient,omitempty"`
-	Metadata
+	*Metadata
 }
 
 // BroadcastsOption specifies the optional parameters for broadcasts endpoint
@@ -44,13 +44,13 @@ type BroadcastsOption struct {
 // getBroadcastsResponse represents a response
 // from broadcast endpoints
 type getBroadcastsResponse struct {
-	Broadcasts []Broadcast `json:"broadcasts,omitempty"`
+	Broadcasts []*Broadcast `json:"broadcasts,omitempty"`
 }
 
 // List fetches a list of broadcasts for the current user
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/broadcasts#for_current_user
-func (bs *BroadcastsService) List(ctx context.Context, opt *BroadcastsOption) ([]Broadcast, *http.Response, error) {
+func (bs *BroadcastsService) List(ctx context.Context, opt *BroadcastsOption) ([]*Broadcast, *http.Response, error) {
 	u, err := urlWithOptions("/broadcasts", opt)
 	if err != nil {
 		return nil, nil, err

--- a/broadcasts_test.go
+++ b/broadcasts_test.go
@@ -29,7 +29,7 @@ func TestBroadcastsService_List(t *testing.T) {
 		t.Errorf("Broadcasts.List returned error: %v", err)
 	}
 
-	want := []Broadcast{{Id: 125, Message: "We just switched the default image for", Active: true, CreatedAt: "2014-11-19T14:39:51Z"}}
+	want := []*Broadcast{{Id: 125, Message: "We just switched the default image for", Active: true, CreatedAt: "2014-11-19T14:39:51Z"}}
 	if !reflect.DeepEqual(broadcasts, want) {
 		t.Errorf("Broadcasts.List returned %+v, want %+v", broadcasts, want)
 	}

--- a/builds_integration_test.go
+++ b/builds_integration_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestBuildService_Integration_Find(t *testing.T) {
-	build, res, err := integrationClient.Builds.Find(context.TODO(), integrationBuildId)
+	build, res, err := integrationClient.Builds.Find(context.TODO(), integrationBuildId, &BuildOption{Include: []string{"build.commit"}})
 
 	if err != nil {
 		t.Fatalf("unexpected error occured: %s", err)
@@ -36,6 +36,7 @@ func TestBuildsService_Integration_List(t *testing.T) {
 		{Limit: 1},
 		{SortBy: "id"},
 		{Offset: 0},
+		{Include: []string{"build.branch", "build.commit"}},
 	}
 
 	for i, opt := range cases {
@@ -52,6 +53,8 @@ func TestBuildsService_Integration_List(t *testing.T) {
 		if len(builds) == 0 {
 			t.Fatalf("#%d returned empty builds", i)
 		}
+
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 
@@ -66,6 +69,7 @@ func TestBuildsService_Integration_ListByRepoId(t *testing.T) {
 		{EventType: []string{BuildEventTypePush}},
 		{CreatedBy: []string{"shuheiktgwtest"}},
 		{BranchName: []string{"master", "test"}},
+		{Include: []string{"build.branch", "build.commit"}},
 	}
 
 	for i, opt := range cases {
@@ -82,6 +86,8 @@ func TestBuildsService_Integration_ListByRepoId(t *testing.T) {
 		if len(builds) == 0 {
 			t.Fatalf("#%d returned empty builds", i)
 		}
+
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 
@@ -95,6 +101,7 @@ func TestBuildsService_Integration_ListByRepoSlug(t *testing.T) {
 		{PreviousState: []string{BuildStatePassed}},
 		{EventType: []string{BuildEventTypePush}},
 		{CreatedBy: []string{"shuheiktgwtest"}},
+		{Include: []string{"build.branch", "build.commit"}},
 	}
 
 	for i, opt := range cases {
@@ -111,6 +118,8 @@ func TestBuildsService_Integration_ListByRepoSlug(t *testing.T) {
 		if len(builds) == 0 {
 			t.Fatalf("#%d returned empty builds", i)
 		}
+
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 

--- a/builds_test.go
+++ b/builds_test.go
@@ -21,10 +21,11 @@ func TestBuildsService_Find(t *testing.T) {
 
 	mux.HandleFunc(fmt.Sprintf("/build/%d", testBuildId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
+		testFormValues(t, r, values{"include": "build.commit,build.branch"})
 		fmt.Fprint(w, `{"id":1,"number":"1","state":"created","duration":10}`)
 	})
 
-	build, _, err := client.Builds.Find(context.Background(), testBuildId)
+	build, _, err := client.Builds.Find(context.Background(), testBuildId, &BuildOption{Include: []string{"build.commit", "build.branch"}})
 
 	if err != nil {
 		t.Errorf("Build.Find returned error: %v", err)
@@ -42,17 +43,17 @@ func TestBuildsService_List(t *testing.T) {
 
 	mux.HandleFunc("/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		testFormValues(t, r, values{"limit": "50", "sort_by": "id"})
+		testFormValues(t, r, values{"limit": "50", "sort_by": "id", "include": "build.commit,build.branch"})
 		fmt.Fprint(w, `{"builds": [{"id":1,"number":"1","state":"created","duration":10}]}`)
 	})
 
-	builds, _, err := client.Builds.List(context.Background(), &BuildsOption{Limit: 50, SortBy: "id"})
+	builds, _, err := client.Builds.List(context.Background(), &BuildsOption{Limit: 50, SortBy: "id", Include: []string{"build.commit", "build.branch"}})
 
 	if err != nil {
 		t.Errorf("Builds.Find returned error: %v", err)
 	}
 
-	want := []Build{{Id: testBuildId, Number: "1", State: BuildStateCreated, Duration: 10}}
+	want := []*Build{{Id: testBuildId, Number: "1", State: BuildStateCreated, Duration: 10}}
 	if !reflect.DeepEqual(builds, want) {
 		t.Errorf("Builds.Find returned %+v, want %+v", builds, want)
 	}
@@ -74,7 +75,7 @@ func TestBuildsService_ListByRepoId(t *testing.T) {
 		t.Errorf("Builds.FindByRepoId returned error: %v", err)
 	}
 
-	want := []Build{{Id: testBuildId, Number: "1", State: BuildStateCreated, Duration: 10}}
+	want := []*Build{{Id: testBuildId, Number: "1", State: BuildStateCreated, Duration: 10}}
 	if !reflect.DeepEqual(builds, want) {
 		t.Errorf("Builds.FindByRepoId returned %+v, want %+v", builds, want)
 	}
@@ -96,7 +97,7 @@ func TestBuildsService_ListByRepoSlug(t *testing.T) {
 		t.Errorf("Builds.FindByRepoSlug returned error: %v", err)
 	}
 
-	want := []Build{{Id: testBuildId, Number: "1", State: BuildStateCreated, Duration: 10}}
+	want := []*Build{{Id: testBuildId, Number: "1", State: BuildStateCreated, Duration: 10}}
 	if !reflect.DeepEqual(builds, want) {
 		t.Errorf("Builds.FindByRepoSlug returned %+v, want %+v", builds, want)
 	}
@@ -117,7 +118,7 @@ func TestBuildsService_Cancel(t *testing.T) {
 		t.Errorf("Build.Cancel returned error: %v", err)
 	}
 
-	want := &MinimalBuild{Id: testBuildId, Number: "1", State: BuildStateCreated, Duration: 10}
+	want := &Build{Id: testBuildId, Number: "1", State: BuildStateCreated, Duration: 10}
 	if !reflect.DeepEqual(build, want) {
 		t.Errorf("Build.Cancel returned %+v, want %+v", build, want)
 	}
@@ -138,7 +139,7 @@ func TestBuildsService_Restart(t *testing.T) {
 		t.Errorf("Build.Restart returned error: %v", err)
 	}
 
-	want := &MinimalBuild{Id: testBuildId, Number: "1", State: BuildStateCreated, Duration: 10}
+	want := &Build{Id: testBuildId, Number: "1", State: BuildStateCreated, Duration: 10}
 	if !reflect.DeepEqual(build, want) {
 		t.Errorf("Build.Restart returned %+v, want %+v", build, want)
 	}

--- a/caches.go
+++ b/caches.go
@@ -26,19 +26,19 @@ type Cache struct {
 	Branch string `json:"branch,omitempty"`
 	// The string to match against the cache name
 	Match string `json:"match,omitempty"`
-	Metadata
+	*Metadata
 }
 
 // cachesResponse represents the response of a call
 // to the Travis CI caches endpoint.
 type cachesResponse struct {
-	Caches []Cache `json:"caches"`
+	Caches []*Cache `json:"caches"`
 }
 
 // ListByRepoId fetches caches based on the given repository id
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/caches#find
-func (cs *CachesService) ListByRepoId(ctx context.Context, repoId uint) ([]Cache, *http.Response, error) {
+func (cs *CachesService) ListByRepoId(ctx context.Context, repoId uint) ([]*Cache, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/caches", repoId), nil)
 	if err != nil {
 		return nil, nil, err
@@ -61,7 +61,7 @@ func (cs *CachesService) ListByRepoId(ctx context.Context, repoId uint) ([]Cache
 // ListByRepoSlug fetches caches based on the given repository slug
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/caches#find
-func (cs *CachesService) ListByRepoSlug(ctx context.Context, repoSlug string) ([]Cache, *http.Response, error) {
+func (cs *CachesService) ListByRepoSlug(ctx context.Context, repoSlug string) ([]*Cache, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/caches", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, nil, err
@@ -84,7 +84,7 @@ func (cs *CachesService) ListByRepoSlug(ctx context.Context, repoSlug string) ([
 // DeleteByRepoId deletes caches based on the given repository id
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/caches#delete
-func (cs *CachesService) DeleteByRepoId(ctx context.Context, repoId uint) ([]Cache, *http.Response, error) {
+func (cs *CachesService) DeleteByRepoId(ctx context.Context, repoId uint) ([]*Cache, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/caches", repoId), nil)
 	if err != nil {
 		return nil, nil, err
@@ -107,7 +107,7 @@ func (cs *CachesService) DeleteByRepoId(ctx context.Context, repoId uint) ([]Cac
 // DeleteByRepoSlug deletes caches based on the given repository slug
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/caches#delete
-func (cs *CachesService) DeleteByRepoSlug(ctx context.Context, repoSlug string) ([]Cache, *http.Response, error) {
+func (cs *CachesService) DeleteByRepoSlug(ctx context.Context, repoSlug string) ([]*Cache, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/caches", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, nil, err

--- a/caches_test.go
+++ b/caches_test.go
@@ -28,7 +28,7 @@ func TestCachesService_ListByRepoId(t *testing.T) {
 		t.Errorf("Caches.FindByRepoId returned error: %v", err)
 	}
 
-	want := []Cache{{Branch: "master", Match: "test"}}
+	want := []*Cache{{Branch: "master", Match: "test"}}
 	if !reflect.DeepEqual(caches, want) {
 		t.Errorf("Caches.FindByRepoId returned %+v, want %+v", caches, want)
 	}
@@ -49,7 +49,7 @@ func TestCachesService_ListByRepoSlug(t *testing.T) {
 		t.Errorf("Caches.FindByRepoSlug returned error: %v", err)
 	}
 
-	want := []Cache{{Branch: "master", Match: "test"}}
+	want := []*Cache{{Branch: "master", Match: "test"}}
 	if !reflect.DeepEqual(caches, want) {
 		t.Errorf("Caches.FindByRepoSlug returned %+v, want %+v", caches, want)
 	}
@@ -70,7 +70,7 @@ func TestCachesService_DeleteByRepoId(t *testing.T) {
 		t.Errorf("Caches.DeleteByRepoId returned error: %v", err)
 	}
 
-	want := []Cache{{Branch: "master", Match: "test"}}
+	want := []*Cache{{Branch: "master", Match: "test"}}
 	if !reflect.DeepEqual(caches, want) {
 		t.Errorf("Caches.DeleteByRepoId returned %+v, want %+v", caches, want)
 	}
@@ -91,7 +91,7 @@ func TestCachesService_DeleteByRepoSlug(t *testing.T) {
 		t.Errorf("Caches.DeleteByRepoSlug returned error: %v", err)
 	}
 
-	want := []Cache{{Branch: "master", Match: "test"}}
+	want := []*Cache{{Branch: "master", Match: "test"}}
 	if !reflect.DeepEqual(caches, want) {
 		t.Errorf("Caches.DeleteByRepoSlug returned %+v, want %+v", caches, want)
 	}

--- a/commits.go
+++ b/commits.go
@@ -5,20 +5,34 @@
 
 package travis
 
-// MinimalCommit is a minimal representation of a GitHub commit as seen by Travis CI
+// Commit is a standard representation of a GitHub commit as seen by Travis CI
 //
-// Travis CI API docs: https://developer.travis-ci.com/resource/commit#minimal-representation
-type MinimalCommit struct {
+// Travis CI API docs: https://developer.travis-ci.com/resource/commit#standard-representation
+type Commit struct {
 	// Value uniquely identifying the commit
 	Id uint `json:"id,omitempty"`
 	// Checksum the commit has in git and is identified by
 	Sha string `json:"sha,omitempty"`
 	// Named reference the commit has in git.
 	Ref string `json:"ref,omitempty"`
-	// Commit mesage
+	// Commit message
 	Message string `json:"message,omitempty"`
 	// URL to the commit's diff on GitHub
 	CompareUrl string `json:"compare_url,omitempty"`
 	// Commit date from git
 	CommittedAt string `json:"committed_at,omitempty"`
+	// Committer of the commit
+	Committer *Committer `json:"committer,omitempty"`
+	// Author of the commit
+	Author *Author `json:"author,omitempty"`
+	*Metadata
 }
+
+// Committer is a committer of the commit
+type Committer struct {
+	Name      string `json:"name,omitempty"`
+	AvatarURL string `json:"avatar_url,omitempty"`
+}
+
+// Author is an author of the commit
+type Author Committer

--- a/crons.go
+++ b/crons.go
@@ -25,9 +25,9 @@ type Cron struct {
 	// Value uniquely identifying the cron
 	Id uint `json:"id,omitempty"`
 	// Github repository to which this cron belongs
-	Repository MinimalRepository `json:"repository,omitempty"`
+	Repository *Repository `json:"repository,omitempty"`
 	// Git branch of repository to which this cron belongs
-	Branch MinimalBranch `json:"branch,omitempty"`
+	Branch *Branch `json:"branch,omitempty"`
 	// Interval at which the cron will run (can be "daily", "weekly" or "monthly")
 	Interval string `json:"interval,omitempty"`
 	// Whether a cron build should run if there has been a build on this branch in the last 24 hours
@@ -40,7 +40,7 @@ type Cron struct {
 	CreatedAt string `json:"created_at,omitempty"`
 	// Whether the cron is active or not
 	Active bool `json:"active,omitempty"`
-	Metadata
+	*Metadata
 }
 
 // CronBody specifies body for
@@ -64,7 +64,7 @@ type CronsOption struct {
 // getCronsResponse represents a response
 // from crons endpoints
 type getCronsResponse struct {
-	Crons []Cron `json:"crons,omitempty"`
+	Crons []*Cron `json:"crons,omitempty"`
 }
 
 const (
@@ -145,7 +145,7 @@ func (cs *CronsService) FindByRepoSlug(ctx context.Context, repoSlug string, bra
 // ListByRepoId fetches crons based on the provided repository id
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/crons#for_repository
-func (cs *CronsService) ListByRepoId(ctx context.Context, repoId uint, opt *CronsOption) ([]Cron, *http.Response, error) {
+func (cs *CronsService) ListByRepoId(ctx context.Context, repoId uint, opt *CronsOption) ([]*Cron, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/crons", repoId), opt)
 	if err != nil {
 		return nil, nil, err
@@ -168,7 +168,7 @@ func (cs *CronsService) ListByRepoId(ctx context.Context, repoId uint, opt *Cron
 // ListByRepoSlug fetches crons based on the provided repository slug
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/crons#for_repository
-func (cs *CronsService) ListByRepoSlug(ctx context.Context, repoSlug string, opt *CronsOption) ([]Cron, *http.Response, error) {
+func (cs *CronsService) ListByRepoSlug(ctx context.Context, repoSlug string, opt *CronsOption) ([]*Cron, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/crons", url.QueryEscape(repoSlug)), opt)
 	if err != nil {
 		return nil, nil, err

--- a/crons_test.go
+++ b/crons_test.go
@@ -95,7 +95,7 @@ func TestCronsService_ListByRepoId(t *testing.T) {
 		t.Errorf("Crons.FindByRepoId returned error: %v", err)
 	}
 
-	want := []Cron{{Id: testCronId, Interval: CronIntervalWeekly, DontRunIfRecentBuildExists: true, Active: true}}
+	want := []*Cron{{Id: testCronId, Interval: CronIntervalWeekly, DontRunIfRecentBuildExists: true, Active: true}}
 	if !reflect.DeepEqual(crons, want) {
 		t.Errorf("Crons.FindByRepoId returned %+v, want %+v", crons, want)
 	}
@@ -118,7 +118,7 @@ func TestCronsService_ListByRepoSlug(t *testing.T) {
 		t.Errorf("Crons.FindByRepoSlug returned error: %v", err)
 	}
 
-	want := []Cron{{Id: testCronId, Interval: CronIntervalWeekly, DontRunIfRecentBuildExists: true, Active: true}}
+	want := []*Cron{{Id: testCronId, Interval: CronIntervalWeekly, DontRunIfRecentBuildExists: true, Active: true}}
 	if !reflect.DeepEqual(crons, want) {
 		t.Errorf("Crons.FindByRepoSlug returned %+v, want %+v", crons, want)
 	}

--- a/env_vars.go
+++ b/env_vars.go
@@ -30,7 +30,7 @@ type EnvVar struct {
 	Value string `json:"value,omitempty"`
 	// Whether this environment variable should be publicly visible or not
 	Public bool `json:"public,omitempty"`
-	Metadata
+	*Metadata
 }
 
 // EnvVarBody specifies options for
@@ -47,7 +47,7 @@ type EnvVarBody struct {
 // getEnvVarsResponse represents the response of a call
 // to the Travis CI env vars endpoint.
 type getEnvVarsResponse struct {
-	EnvVars []EnvVar `json:"env_vars"`
+	EnvVars []*EnvVar `json:"env_vars"`
 }
 
 // FindByRepoId fetches environment variable based on the given repository id and env var id
@@ -99,7 +99,7 @@ func (es *EnvVarsService) FindByRepoSlug(ctx context.Context, repoSlug string, i
 // ListByRepoId fetches environment variables based on the given repository id
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/env_vars#for_repository
-func (es *EnvVarsService) ListByRepoId(ctx context.Context, repoId uint) ([]EnvVar, *http.Response, error) {
+func (es *EnvVarsService) ListByRepoId(ctx context.Context, repoId uint) ([]*EnvVar, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/env_vars", repoId), nil)
 	if err != nil {
 		return nil, nil, err
@@ -122,7 +122,7 @@ func (es *EnvVarsService) ListByRepoId(ctx context.Context, repoId uint) ([]EnvV
 // ListByRepoSlug fetches environment variables based on the given repository slug
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/env_vars#for_repository
-func (es *EnvVarsService) ListByRepoSlug(ctx context.Context, repoSlug string) ([]EnvVar, *http.Response, error) {
+func (es *EnvVarsService) ListByRepoSlug(ctx context.Context, repoSlug string) ([]*EnvVar, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/env_vars", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, nil, err

--- a/env_vars_integration_test.go
+++ b/env_vars_integration_test.go
@@ -100,7 +100,7 @@ func TestEnvVarsService_Integration_CreateAndUpdateAndDeleteEnvVarByRepoId(t *te
 		Name:   "TEST",
 		Value:  "test",
 		Public: true,
-		Metadata: Metadata{
+		Metadata: &Metadata{
 			Type:           "env_var",
 			Href:           fmt.Sprintf("/repo/20783933/env_var/%s", envVar.Id),
 			Representation: "standard",
@@ -131,7 +131,7 @@ func TestEnvVarsService_Integration_CreateAndUpdateAndDeleteEnvVarByRepoId(t *te
 		Name:   "NEW_TEST",
 		Value:  "",
 		Public: false,
-		Metadata: Metadata{
+		Metadata: &Metadata{
 			Type:           "env_var",
 			Href:           fmt.Sprintf("/repo/20783933/env_var/%s", envVar.Id),
 			Representation: "standard",
@@ -175,7 +175,7 @@ func TestEnvVarsService_Integration_CreateAndUpdateAndDeleteEnvVarByRepoSlug(t *
 		Name:   "TEST",
 		Value:  "test",
 		Public: true,
-		Metadata: Metadata{
+		Metadata: &Metadata{
 			Type:           "env_var",
 			Href:           fmt.Sprintf("/repo/20783933/env_var/%s", envVar.Id),
 			Representation: "standard",
@@ -206,7 +206,7 @@ func TestEnvVarsService_Integration_CreateAndUpdateAndDeleteEnvVarByRepoSlug(t *
 		Name:   "NEW_TEST",
 		Value:  "",
 		Public: false,
-		Metadata: Metadata{
+		Metadata: &Metadata{
 			Type:           "env_var",
 			Href:           fmt.Sprintf("/repo/20783933/env_var/%s", envVar.Id),
 			Representation: "standard",

--- a/env_vars_test.go
+++ b/env_vars_test.go
@@ -72,7 +72,7 @@ func TestEnvVarsService_ListByRepoId(t *testing.T) {
 		t.Errorf("EnvVars.FindByRepoId returned error: %v", err)
 	}
 
-	want := []EnvVar{{Id: testEnvVarId, Name: "TEST", Value: "test", Public: false}}
+	want := []*EnvVar{{Id: testEnvVarId, Name: "TEST", Value: "test", Public: false}}
 	if !reflect.DeepEqual(envVar, want) {
 		t.Errorf("EnvVars.FindByRepoId returned %+v, want %+v", envVar, want)
 	}
@@ -93,7 +93,7 @@ func TestEnvVarsService_ListByRepoSlug(t *testing.T) {
 		t.Errorf("EnvVars.FindByRepoSlug returned error: %v", err)
 	}
 
-	want := []EnvVar{{Id: testEnvVarId, Name: "TEST", Value: "test", Public: false}}
+	want := []*EnvVar{{Id: testEnvVarId, Name: "TEST", Value: "test", Public: false}}
 	if !reflect.DeepEqual(envVar, want) {
 		t.Errorf("EnvVars.FindByRepoSlug returned %+v, want %+v", envVar, want)
 	}

--- a/installatios.go
+++ b/installatios.go
@@ -26,8 +26,8 @@ type Installation struct {
 	// The installation's id on GitHub
 	GitHubId uint `json:"github_id,omitempty"`
 	// GitHub user or organization the installation belongs to
-	Owner MinimalOwner `json:"owner,omitempty"`
-	Metadata
+	Owner *Owner `json:"owner,omitempty"`
+	*Metadata
 }
 
 // Find fetches a single GitHub installation based on the provided id.

--- a/jobs.go
+++ b/jobs.go
@@ -34,32 +34,24 @@ type Job struct {
 	// When the job finished
 	FinishedAt string `json:"finished_at,omitempty"`
 	// The build the job is associated with
-	Build MinimalBuild `json:"build,omitempty"`
+	Build *Build `json:"build,omitempty"`
 	// Worker queue this job is/was scheduled on
 	Queue string `json:"queue,omitempty"`
 	// GitHub repository the job is associated with
-	Repository MinimalRepository `json:"repository,omitempty"`
+	Repository *Repository `json:"repository,omitempty"`
 	// The commit the job is associated with
-	Commit MinimalCommit `json:"commit,omitempty"`
+	Commit *Commit `json:"commit,omitempty"`
 	// GitHub user or organization the job belongs to
-	Owner MinimalOwner `json:"owner,omitempty"`
+	Owner *Owner `json:"owner,omitempty"`
 	// The stages of the job
-	Stage MinimalStage `json:"stage,omitempty"`
+	Stage *Stage `json:"stage,omitempty"`
 	// When the job was created
 	CreatedAt string `json:"created_at,omitempty"`
 	// When the job was updated
 	UpdatedAt string `json:"updated_at,omitempty"`
 	// Whether or not the job is private
 	Private bool `json:"private,omitempty"`
-	Metadata
-}
-
-// MinimalJob is a minimal representation of a Travis CI job
-//
-// Travis CI API docs: https://developer.travis-ci.com/resource/job#standard-representation
-type MinimalJob struct {
-	// Value uniquely identifying the job
-	Id uint `json:"id,omitempty"`
+	*Metadata
 }
 
 // JobsOption is query parameters to one can specify
@@ -76,12 +68,12 @@ type JobsOption struct {
 }
 
 type getJobsResponse struct {
-	Jobs []Job `json:"jobs"`
+	Jobs []*Job `json:"jobs"`
 }
 
 // jobResponse is only used to parse responses from Restart, Cancel and Debug
 type jobResponse struct {
-	Job MinimalJob `json:"job,omitempty"`
+	Job *Job `json:"job,omitempty"`
 }
 
 const (
@@ -125,7 +117,7 @@ func (js *JobsService) Find(ctx context.Context, id uint) (*Job, *http.Response,
 // ListByBuild fetches jobs based on the provided build id
 //
 // Travis CI API docs: https://developer.travis-ci.csom/resource/jobs#find
-func (js *JobsService) ListByBuild(ctx context.Context, buildId uint) ([]Job, *http.Response, error) {
+func (js *JobsService) ListByBuild(ctx context.Context, buildId uint) ([]*Job, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/build/%d/jobs", buildId), nil)
 	if err != nil {
 		return nil, nil, err
@@ -150,7 +142,7 @@ func (js *JobsService) ListByBuild(ctx context.Context, buildId uint) ([]Job, *h
 // See jobs_integration_test.go, TestJobsService_Find
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/jobs#find
-func (js *JobsService) List(ctx context.Context, opt *JobsOption) ([]Job, *http.Response, error) {
+func (js *JobsService) List(ctx context.Context, opt *JobsOption) ([]*Job, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/jobs"), opt)
 	if err != nil {
 		return nil, nil, err
@@ -173,7 +165,7 @@ func (js *JobsService) List(ctx context.Context, opt *JobsOption) ([]Job, *http.
 // Cancel cancels a job based on the provided job id
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/job#cancel
-func (js *JobsService) Cancel(ctx context.Context, id uint) (*MinimalJob, *http.Response, error) {
+func (js *JobsService) Cancel(ctx context.Context, id uint) (*Job, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/job/%d/cancel", id), nil)
 	if err != nil {
 		return nil, nil, err
@@ -190,13 +182,13 @@ func (js *JobsService) Cancel(ctx context.Context, id uint) (*MinimalJob, *http.
 		return nil, resp, err
 	}
 
-	return &jobResponse.Job, resp, err
+	return jobResponse.Job, resp, err
 }
 
 // Restart restarts a job based on the provided job id
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/job#restart
-func (js *JobsService) Restart(ctx context.Context, id uint) (*MinimalJob, *http.Response, error) {
+func (js *JobsService) Restart(ctx context.Context, id uint) (*Job, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/job/%d/restart", id), nil)
 	if err != nil {
 		return nil, nil, err
@@ -213,7 +205,7 @@ func (js *JobsService) Restart(ctx context.Context, id uint) (*MinimalJob, *http
 		return nil, resp, err
 	}
 
-	return &jobResponse.Job, resp, err
+	return jobResponse.Job, resp, err
 }
 
 // Debug restarts a job in debug mode based on the provided job id
@@ -221,7 +213,7 @@ func (js *JobsService) Restart(ctx context.Context, id uint) (*MinimalJob, *http
 // to enable the debug feature
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/job#debug
-func (js *JobsService) Debug(ctx context.Context, id uint) (*MinimalJob, *http.Response, error) {
+func (js *JobsService) Debug(ctx context.Context, id uint) (*Job, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/job/%d/debug", id), nil)
 	if err != nil {
 		return nil, nil, err
@@ -238,5 +230,5 @@ func (js *JobsService) Debug(ctx context.Context, id uint) (*MinimalJob, *http.R
 		return nil, resp, err
 	}
 
-	return &jobResponse.Job, resp, err
+	return jobResponse.Job, resp, err
 }

--- a/jobs_integration_test.go
+++ b/jobs_integration_test.go
@@ -52,7 +52,7 @@ func TestJobsService_Integration_List(t *testing.T) {
 	opt := &JobsOption{}
 	jobs, res, err := integrationClient.Jobs.List(context.TODO(), opt)
 
-	// This endpoint returns 500 as of 2019/09/04
+	// This endpoint returns 500 as of 2019/04/17
 	t.Skip()
 
 	if err != nil {

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -51,7 +51,7 @@ func TestJobsService_ListByBuild(t *testing.T) {
 		t.Errorf("Jobs.ListByBuild returned error: %v", err)
 	}
 
-	want := []Job{{Id: testJobId, AllowFailure: true, Number: "1", State: JobStatusCreated}}
+	want := []*Job{{Id: testJobId, AllowFailure: true, Number: "1", State: JobStatusCreated}}
 	if !reflect.DeepEqual(job, want) {
 		t.Errorf("Jobs.ListByBuild returned %+v, want %+v", job, want)
 	}
@@ -73,7 +73,7 @@ func TestJobsService_List(t *testing.T) {
 		t.Errorf("Jobs.List returned error: %v", err)
 	}
 
-	want := []Job{{Id: testJobId, AllowFailure: true, Number: "1", State: JobStatusCreated}}
+	want := []*Job{{Id: testJobId, AllowFailure: true, Number: "1", State: JobStatusCreated}}
 	if !reflect.DeepEqual(job, want) {
 		t.Errorf("Jobs.List returned %+v, want %+v", job, want)
 	}
@@ -94,7 +94,7 @@ func TestJobsService_Cancel(t *testing.T) {
 		t.Errorf("Job.Cancel returned error: %v", err)
 	}
 
-	want := &MinimalJob{Id: testJobId}
+	want := &Job{Id: testJobId}
 	if !reflect.DeepEqual(job, want) {
 		t.Errorf("Job.Cancel returned %+v, want %+v", job, want)
 	}
@@ -115,7 +115,7 @@ func TestJobsService_Restart(t *testing.T) {
 		t.Errorf("Job.Restart returned error: %v", err)
 	}
 
-	want := &MinimalJob{Id: testJobId}
+	want := &Job{Id: testJobId}
 	if !reflect.DeepEqual(job, want) {
 		t.Errorf("Job.Restart returned %+v, want %+v", job, want)
 	}
@@ -136,7 +136,7 @@ func TestJobsService_Debug(t *testing.T) {
 		t.Errorf("Job.Debug returned error: %v", err)
 	}
 
-	want := &MinimalJob{Id: testJobId}
+	want := &Job{Id: testJobId}
 	if !reflect.DeepEqual(job, want) {
 		t.Errorf("Job.Debug returned %+v, want %+v", job, want)
 	}

--- a/lint.go
+++ b/lint.go
@@ -27,17 +27,17 @@ type TravisYml struct {
 type Warning struct {
 	Key     []string `json:"key,omitempty"`
 	Message string   `json:"message,omitempty"`
-	Metadata
+	*Metadata
 }
 
 type lintResponse struct {
-	Warnings []Warning `json:"warnings,omitempty"`
+	Warnings []*Warning `json:"warnings,omitempty"`
 }
 
 // Lint validates the .travis.yml file and returns any warnings
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/lint#lint
-func (es *LintService) Lint(ctx context.Context, yml *TravisYml) ([]Warning, *http.Response, error) {
+func (es *LintService) Lint(ctx context.Context, yml *TravisYml) ([]*Warning, *http.Response, error) {
 	u, err := urlWithOptions("/lint", nil)
 	if err != nil {
 		return nil, nil, err

--- a/lint_test.go
+++ b/lint_test.go
@@ -29,7 +29,7 @@ func TestLintService_Lint(t *testing.T) {
 		t.Errorf("Lint.Lint returned error: %v", err)
 	}
 
-	want := []Warning{{Key: []string{"test"}, Message: "test!"}}
+	want := []*Warning{{Key: []string{"test"}, Message: "test!"}}
 	if !reflect.DeepEqual(warnings, want) {
 		t.Errorf("Lint.Lint returned %+v, want %+v", warnings, want)
 	}

--- a/logs.go
+++ b/logs.go
@@ -24,8 +24,8 @@ type Log struct {
 	// The content of the log
 	Content string `json:"content,omitempty"`
 	// The log parts that form the log
-	LogParts []LogPart `json:"log_parts,omitempty"`
-	Metadata
+	LogParts []*LogPart `json:"log_parts,omitempty"`
+	*Metadata
 }
 
 // 	LogPart is parts that form the log

--- a/organizations.go
+++ b/organizations.go
@@ -33,7 +33,7 @@ type Organization struct {
 	AvatarUrl string `json:"avatar_url,omitempty"`
 	// Whether or not the organization has an education account
 	Education bool `json:"education,omitempty"`
-	Metadata
+	*Metadata
 }
 
 // OrganizationsOption specifies the optional parameters for organizations endpoint
@@ -49,7 +49,7 @@ type OrganizationsOption struct {
 // getOrganizationsResponse represents a response
 // from organizations endpoints
 type getOrganizationsResponse struct {
-	Organizations []Organization `json:"organizations,omitempty"`
+	Organizations []*Organization `json:"organizations,omitempty"`
 }
 
 // Find fetches an organization with the given id
@@ -78,7 +78,7 @@ func (os *OrganizationsService) Find(ctx context.Context, id uint) (*Organizatio
 // List fetches a list of organizations the current user is a member of
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/organizations#for_current_user
-func (os *OrganizationsService) List(ctx context.Context, opt *OrganizationsOption) ([]Organization, *http.Response, error) {
+func (os *OrganizationsService) List(ctx context.Context, opt *OrganizationsOption) ([]*Organization, *http.Response, error) {
 	u, err := urlWithOptions("/orgs", opt)
 	if err != nil {
 		return nil, nil, err

--- a/organizations_integration_test.go
+++ b/organizations_integration_test.go
@@ -34,11 +34,11 @@ func TestOrganizationsService_Integration_Find(t *testing.T) {
 		GithubId:  351550,
 		AvatarUrl: "https://avatars1.githubusercontent.com/u/351550",
 		Education: false,
-		Metadata: Metadata{
+		Metadata: &Metadata{
 			Type:           "organization",
 			Href:           "/org/111",
 			Representation: "standard",
-			Permissions:    Permissions{"read": true, "sync": false},
+			Permissions:    Permissions{"read": true, "admin": false, "sync": false},
 		},
 	}
 

--- a/organizations_test.go
+++ b/organizations_test.go
@@ -51,7 +51,7 @@ func TestOrganizationsService_List(t *testing.T) {
 		t.Errorf("Organizations.List returned error: %v", err)
 	}
 
-	want := []Organization{{Id: 111, Login: "TestOrg", Name: "TestOrg", GithubId: 12345, AvatarUrl: "https:///test.com", Education: false}}
+	want := []*Organization{{Id: 111, Login: "TestOrg", Name: "TestOrg", GithubId: 12345, AvatarUrl: "https:///test.com", Education: false}}
 	if !reflect.DeepEqual(orgs, want) {
 		t.Errorf("Organizations.List returned %+v, want %+v", orgs, want)
 	}

--- a/owner.go
+++ b/owner.go
@@ -33,17 +33,7 @@ type Owner struct {
 	AvatarUrl string `json:"avatar_url"`
 	// Whether or not the owner has an education account
 	Education bool `json:"education"`
-	Metadata
-}
-
-// MinimalOwner represents a minimal GitHub Owner
-//
-// Travis CI API docs: https://developer.travis-ci.com/resource/owner#minimal-representation
-type MinimalOwner struct {
-	// // Value uniquely identifying the owner
-	Id uint `json:"id"`
-	// User or organization login set on GitHub
-	Login string `json:"login"`
+	*Metadata
 }
 
 // Find fetches a owner based on the provided login

--- a/owner_integration_test.go
+++ b/owner_integration_test.go
@@ -30,8 +30,6 @@ func TestOwnerService_Integration_FindByLogin(t *testing.T) {
 }
 
 func TestOwnerService_Integration_FindByGitHubId(t *testing.T) {
-	t.Parallel()
-
 	owner, res, err := integrationClient.Owner.FindByGitHubId(context.TODO(), integrationGitHubOwnerId)
 
 	if err != nil {

--- a/preferences.go
+++ b/preferences.go
@@ -24,12 +24,12 @@ type Preference struct {
 	// The preference's name
 	Name string `json:"name,omitempty"`
 	// The preference's value
-	Value bool `json:"value"`
-	Metadata
+	Value interface{} `json:"value"`
+	*Metadata
 }
 
 type getPreferencesResponse struct {
-	Preferences []Preference `json:"preferences,omitempty"`
+	Preferences []*Preference `json:"preferences,omitempty"`
 }
 
 // Find fetches the current user's preference based on
@@ -59,7 +59,7 @@ func (ps *PreferencesService) Find(ctx context.Context, name string) (*Preferenc
 // List fetches the current user's preferences
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/preferences#for_user
-func (ps *PreferencesService) List(ctx context.Context) ([]Preference, *http.Response, error) {
+func (ps *PreferencesService) List(ctx context.Context) ([]*Preference, *http.Response, error) {
 	u, err := urlWithOptions("/preferences", nil)
 	if err != nil {
 		return nil, nil, err

--- a/preferences_integration_test.go
+++ b/preferences_integration_test.go
@@ -30,7 +30,7 @@ func TestPreferencesService_Integration_Find(t *testing.T) {
 	want := &Preference{
 		Name:     integrationPreferenceName,
 		Value:    true,
-		Metadata: Metadata{Type: "preference", Href: "/preference/build_emails", Representation: "standard"},
+		Metadata: &Metadata{Type: "preference", Href: "/v3/preference/build_emails", Representation: "standard"},
 	}
 
 	if !reflect.DeepEqual(preference, want) {
@@ -42,18 +42,25 @@ func TestPreferencesService_Integration_List(t *testing.T) {
 	preferences, res, err := integrationClient.Preferences.List(context.TODO())
 
 	if err != nil {
-		t.Fatalf("Preferences.Find unexpected error occured: %s", err)
+		t.Fatalf("Preferences.List unexpected error occured: %s", err)
 	}
 
 	if res.StatusCode != http.StatusOK {
-		t.Fatalf("Preferences.Find invalid http status: %s", res.Status)
+		t.Fatalf("Preferences.List invalid http status: %s", res.Status)
 	}
 
-	want := []Preference{{
-		Name:     "build_emails",
-		Value:    true,
-		Metadata: Metadata{Type: "preference", Href: "/preference/build_emails", Representation: "standard"},
-	}}
+	want := []*Preference{
+		{
+			Name:     "build_emails",
+			Value:    true,
+			Metadata: &Metadata{Type: "preference", Href: "/v3/preference/build_emails", Representation: "standard"},
+		},
+		{
+			Name:     "private_insights_visibility",
+			Value:    "private",
+			Metadata: &Metadata{Type: "preference", Href: "/v3/preference/private_insights_visibility", Representation: "standard"},
+		},
+	}
 
 	if !reflect.DeepEqual(preferences, want) {
 		t.Errorf("Preferences.Find returned %+v, want %+v", preferences, want)
@@ -75,7 +82,7 @@ func TestPreferenceServices_Integration_Update(t *testing.T) {
 	want := &Preference{
 		Name:     integrationPreferenceName,
 		Value:    false,
-		Metadata: Metadata{Type: "preference", Href: "/preference/build_emails", Representation: "standard"},
+		Metadata: &Metadata{Type: "preference", Href: "/v3/preference/build_emails", Representation: "standard"},
 	}
 
 	if !reflect.DeepEqual(preference, want) {
@@ -96,7 +103,7 @@ func TestPreferenceServices_Integration_Update(t *testing.T) {
 	want = &Preference{
 		Name:     integrationPreferenceName,
 		Value:    true,
-		Metadata: Metadata{Type: "preference", Href: "/preference/build_emails", Representation: "standard"},
+		Metadata: &Metadata{Type: "preference", Href: "/v3/preference/build_emails", Representation: "standard"},
 	}
 	if !reflect.DeepEqual(preference, want) {
 		t.Errorf("Preference.Update returned %+v, want %+v", preference, want)

--- a/preferences_test.go
+++ b/preferences_test.go
@@ -51,7 +51,7 @@ func TestPreferencesService_List(t *testing.T) {
 		t.Errorf("Preferences.Find returned error: %v", err)
 	}
 
-	want := []Preference{{Name: "builds_email", Value: true}}
+	want := []*Preference{{Name: "builds_email", Value: true}}
 	if !reflect.DeepEqual(preferences, want) {
 		t.Errorf("Preferences.Find returned %+v, want %+v", preferences, want)
 	}

--- a/repositories.go
+++ b/repositories.go
@@ -40,28 +40,16 @@ type Repository struct {
 	// Whether or not this repository is private
 	Private bool `json:"private"`
 	// GitHub user or organization the repository belongs to
-	Owner MinimalOwner `json:"owner"`
+	Owner *Owner `json:"owner"`
 	// The default branch on GitHub
-	DefaultBranch MinimalBranch `json:"default_branch"`
+	DefaultBranch *Branch `json:"default_branch"`
 	// Whether or not this repository is starred
 	Starred bool `json:"starred"`
 	// Whether or not this repository is managed by a GitHub App installation
 	ManagedByInstallation bool `json:"managed_by_installation"`
 	// Whether or not this repository runs builds on travis-ci.org (may also be null)
 	ActiveOnOrg bool `json:"active_on_org"`
-	Metadata
-}
-
-// MinimalRepository is a minimal representation of a Travis CI repository
-//
-// Travis CI API docs: https://developer.travis-ci.com/resource/repository#minimal-representation
-type MinimalRepository struct {
-	// Value uniquely identifying the repository
-	Id uint `json:"id"`
-	// The repository's name on GitHub
-	Name string `json:"name"`
-	// Same as {repository.owner.name}/{repository.name}
-	Slug string `json:"slug"`
+	*Metadata
 }
 
 // Find fetches a repository based on the provided slug

--- a/requests.go
+++ b/requests.go
@@ -32,34 +32,20 @@ type Request struct {
 	// Travis-ci status message attached to the request.
 	Message string `json:"message,omitempty"`
 	// GitHub user or organization the request belongs to
-	Repository MinimalRepository `json:"repository,omitempty"`
+	Repository *Repository `json:"repository,omitempty"`
 	// Name of the branch requested to be built
 	BranchName string `json:"branch_name,omitempty"`
 	// The commit the request is associated with
-	Commit MinimalCommit `json:"commit,omitempty"`
+	Commit *Commit `json:"commit,omitempty"`
 	// The request's builds
-	Builds []MinimalBuild `json:"builds,omitempty"`
+	Builds []*Build `json:"builds,omitempty"`
 	// GitHub user or organization the request belongs to
-	Owner MinimalOwner `json:"owner,omitempty"`
+	Owner *Owner `json:"owner,omitempty"`
 	// When Travis CI created the request
 	CreatedAt string `json:"created_at,omitempty"`
 	// Origin of request (push, pull request, api)
 	EventType string `json:"event_type,omitempty"`
-	Metadata
-}
-
-// MinimalRequest is a minimal representation a Travis CI request.
-//
-// Travis CI API docs: https://developer.travis-ci.com/resource/request#minimal-representation
-type MinimalRequest struct {
-	// Value uniquely identifying the request
-	Id uint `json:"id,omitempty"`
-	// The state of a request (eg. whether it has been processed or not)
-	State string `json:"state,omitempty"`
-	// The result of the request (eg. rejected or approved)
-	Result string `json:"result,omitempty"`
-	// Travis-ci status message attached to the request.
-	Message string `json:"message,omitempty"`
+	*Metadata
 }
 
 // ListRequestsOption specifies options for
@@ -85,7 +71,7 @@ type RequestBody struct {
 }
 
 type getRequestsResponse struct {
-	Requests []Request `json:"requests"`
+	Requests []*Request `json:"requests"`
 }
 
 // FindByRepoId fetches request of given repository id and request id
@@ -167,13 +153,13 @@ func (rs *RequestsService) FindByRepoSlug(ctx context.Context, repoSlug string, 
 //  "resource_type":      "request"
 //}
 type createRequestResponse struct {
-	Request MinimalRequest `json:"request"`
+	Request Request `json:"request"`
 }
 
 // ListByRepoId fetches requests of given repository id
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/requests#find
-func (rs *RequestsService) ListByRepoId(ctx context.Context, repoId uint, opt *ListRequestsOption) ([]Request, *http.Response, error) {
+func (rs *RequestsService) ListByRepoId(ctx context.Context, repoId uint, opt *ListRequestsOption) ([]*Request, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/requests", repoId), opt)
 	if err != nil {
 		return nil, nil, err
@@ -196,7 +182,7 @@ func (rs *RequestsService) ListByRepoId(ctx context.Context, repoId uint, opt *L
 // ListByRepoSlug fetches requests of given repository slug
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/requests#find
-func (rs *RequestsService) ListByRepoSlug(ctx context.Context, repoSlug string, opt *ListRequestsOption) ([]Request, *http.Response, error) {
+func (rs *RequestsService) ListByRepoSlug(ctx context.Context, repoSlug string, opt *ListRequestsOption) ([]*Request, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/requests", url.QueryEscape(repoSlug)), opt)
 	if err != nil {
 		return nil, nil, err
@@ -219,7 +205,7 @@ func (rs *RequestsService) ListByRepoSlug(ctx context.Context, repoSlug string, 
 // CreateByRepoId create requests of given repository id and provided options
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/requests#create
-func (rs *RequestsService) CreateByRepoId(ctx context.Context, repoId uint, request *RequestBody) (*MinimalRequest, *http.Response, error) {
+func (rs *RequestsService) CreateByRepoId(ctx context.Context, repoId uint, request *RequestBody) (*Request, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/requests", repoId), nil)
 	if err != nil {
 		return nil, nil, err
@@ -242,7 +228,7 @@ func (rs *RequestsService) CreateByRepoId(ctx context.Context, repoId uint, requ
 // CreateByRepoSlug create requests of given repository slug and provided options
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/requests#create
-func (rs *RequestsService) CreateByRepoSlug(ctx context.Context, repoSlug string, request *RequestBody) (*MinimalRequest, *http.Response, error) {
+func (rs *RequestsService) CreateByRepoSlug(ctx context.Context, repoSlug string, request *RequestBody) (*Request, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/requests", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, nil, err

--- a/requests_test.go
+++ b/requests_test.go
@@ -73,7 +73,7 @@ func TestRequestsService_ListByRepoId(t *testing.T) {
 		t.Errorf("RequestsService.FindByRepoId returned error: %v", err)
 	}
 
-	want := []Request{{Id: 1, State: "processed", Result: "rejected"}}
+	want := []*Request{{Id: 1, State: "processed", Result: "rejected"}}
 	if !reflect.DeepEqual(repos, want) {
 		t.Errorf("RequestsService.FindByRepoId returned %+v, want %+v", repos, want)
 	}
@@ -95,7 +95,7 @@ func TestRequestsService_ListByRepoSlug(t *testing.T) {
 		t.Errorf("RequestsService.FindByRepoSlug returned error: %v", err)
 	}
 
-	want := []Request{{Id: 1, State: "processed", Result: "rejected"}}
+	want := []*Request{{Id: 1, State: "processed", Result: "rejected"}}
 	if !reflect.DeepEqual(repos, want) {
 		t.Errorf("RequestsService.FindByRepoSlug returned %+v, want %+v", repos, want)
 	}
@@ -117,7 +117,7 @@ func TestRequestsService_CreateByRepoId(t *testing.T) {
 		t.Errorf("RequestsService.CreateByRepoId returned error: %v", err)
 	}
 
-	want := &MinimalRequest{Id: 1, Message: "message!"}
+	want := &Request{Id: 1, Message: "message!"}
 	if !reflect.DeepEqual(repo, want) {
 		t.Errorf("RequestsService.CreateByRepoId returned %+v, want %+v", repo, want)
 	}
@@ -139,7 +139,7 @@ func TestRequestsService_CreateByRepoSlug(t *testing.T) {
 		t.Errorf("RequestsService.CreateByRepoSlug returned error: %v", err)
 	}
 
-	want := &MinimalRequest{Id: 1, Message: "message!"}
+	want := &Request{Id: 1, Message: "message!"}
 	if !reflect.DeepEqual(repo, want) {
 		t.Errorf("RequestsService.CreateByRepoSlug returned %+v, want %+v", repo, want)
 	}

--- a/settings.go
+++ b/settings.go
@@ -27,12 +27,12 @@ type Setting struct {
 	// The setting's value
 	// Currently value can be boolean or integer
 	Value interface{} `json:"value,omitempty"`
-	Metadata
+	*Metadata
 }
 
 // getSettingsResponse represents response from the settings endpoints
 type getSettingsResponse struct {
-	Settings []Setting `json:"settings,omitempty"`
+	Settings []*Setting `json:"settings,omitempty"`
 }
 
 const (
@@ -99,7 +99,7 @@ func (ss *SettingsService) FindByRepoSlug(ctx context.Context, repoSlug string, 
 // ListByRepoId fetches a list of settings of given repository id
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/settings#for_repository
-func (ss *SettingsService) ListByRepoId(ctx context.Context, repoId uint) ([]Setting, *http.Response, error) {
+func (ss *SettingsService) ListByRepoId(ctx context.Context, repoId uint) ([]*Setting, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/settings", repoId), nil)
 	if err != nil {
 		return nil, nil, err
@@ -122,7 +122,7 @@ func (ss *SettingsService) ListByRepoId(ctx context.Context, repoId uint) ([]Set
 // ListByRepoSlug fetches a list of settings of given repository slug
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/settings#for_repository
-func (ss *SettingsService) ListByRepoSlug(ctx context.Context, repoSlug string) ([]Setting, *http.Response, error) {
+func (ss *SettingsService) ListByRepoSlug(ctx context.Context, repoSlug string) ([]*Setting, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/settings", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, nil, err

--- a/settings_integration_test.go
+++ b/settings_integration_test.go
@@ -29,7 +29,7 @@ func TestSettingsService_Integration_FindByRepoId(t *testing.T) {
 	want := &Setting{
 		Name:  BuildsOnlyWithTravisYmlSetting,
 		Value: false,
-		Metadata: Metadata{
+		Metadata: &Metadata{
 			Type:           "setting",
 			Href:           "/repo/20783933/setting/builds_only_with_travis_yml",
 			Representation: "standard",
@@ -56,7 +56,7 @@ func TestSettingsService_Integration_FindByRepoSlug(t *testing.T) {
 	want := &Setting{
 		Name:  BuildsOnlyWithTravisYmlSetting,
 		Value: false,
-		Metadata: Metadata{
+		Metadata: &Metadata{
 			Type:           "setting",
 			Href:           "/repo/20783933/setting/builds_only_with_travis_yml",
 			Representation: "standard",
@@ -116,7 +116,7 @@ func TestSettingsService_Integration_UpdateByRepoIdAndSlug(t *testing.T) {
 	want := &Setting{
 		Name:  BuildsOnlyWithTravisYmlSetting,
 		Value: true,
-		Metadata: Metadata{
+		Metadata: &Metadata{
 			Type:           "setting",
 			Href:           "/repo/20783933/setting/builds_only_with_travis_yml",
 			Representation: "standard",
@@ -144,7 +144,7 @@ func TestSettingsService_Integration_UpdateByRepoIdAndSlug(t *testing.T) {
 	want = &Setting{
 		Name:  BuildsOnlyWithTravisYmlSetting,
 		Value: false,
-		Metadata: Metadata{
+		Metadata: &Metadata{
 			Type:           "setting",
 			Href:           "/repo/20783933/setting/builds_only_with_travis_yml",
 			Representation: "standard",

--- a/stage.go
+++ b/stage.go
@@ -5,10 +5,10 @@
 
 package travis
 
-// MinimalStage is a minimal representation of an individual stage
+// Stage is a standard representation of an individual stage
 //
-// Travis CI API docs: https://developer.travis-ci.com/resource/stage#minimal-representation
-type MinimalStage struct {
+// Travis CI API docs: https://developer.travis-ci.com/resource/stage#standard-representation
+type Stage struct {
 	// Value uniquely identifying the stage
 	Id uint `json:"id,omitempty"`
 	// Incremental number for a stage
@@ -21,4 +21,7 @@ type MinimalStage struct {
 	StartedAt string `json:"started_at,omitempty"`
 	// When the stage finished
 	FinishedAt string `json:"finished_at,omitempty"`
+	// The jobs of a stage.
+	Jobs []*Job `json:"jobs,omitempty"`
+	*Metadata
 }

--- a/tags.go
+++ b/tags.go
@@ -5,13 +5,13 @@
 
 package travis
 
-// MinimalTag is a minimal representation of a Travis CI tag
-type MinimalTag struct {
+// Tag is a standard representation of a Travis CI tag
+type Tag struct {
 	// Value uniquely identifying a repository of the build belongs to
 	RepositoryId uint `json:"repository_id"`
 	// Name of the tag
 	Name string `json:"name,omitempty"`
 	// Id of a last build on the branch
 	LastBuildId uint `json:"last_build_id"`
-	Metadata
+	*Metadata
 }

--- a/user.go
+++ b/user.go
@@ -37,7 +37,7 @@ type User struct {
 	IsSyncing bool `json:"is_syncing,omitempty"`
 	// The last time the user was synced with GitHub
 	SyncedAt string `json:"synced_at,omitempty"`
-	Metadata
+	*Metadata
 }
 
 // Current fetches the currently authenticated user from Travis CI API.


### PR DESCRIPTION
**This PR contains several potential breaking changes.**

List of changes.

- Remove minimal representations to support eager loading. See https://github.com/shuheiktgw/go-travis/pull/23
- Fix to return a pointer not a struct in order to avoid circular references.
- Fix the build client methods to support eager loading.