### PR TITLE
Add a support for eager loading on the branches and branch endpoints

### DIFF
--- a/branches.go
+++ b/branches.go
@@ -32,11 +32,13 @@ type Branch struct {
 	ExistsOnGithub bool `json:"exists_on_github,omitempty"`
 	// Last build on the branch
 	LastBuild *Build `json:"last_build,omitempty"`
+	// Last 10 builds on the branch (when `include=branch.recent_builds` is used)
+	RecentBuilds []*Build `json:"recent_builds,omitempty"`
 	*Metadata
 }
 
-// ListBranchesOption specifies the optional parameters for branches endpoint
-type ListBranchesOption struct {
+// BranchesOption specifies the optional parameters for branches endpoint
+type BranchesOption struct {
 	// Whether or not the branch still exists on GitHub
 	ExistsOnGithub bool `url:"exists_on_github,omitempty"`
 	// How many branches to include in the response
@@ -45,19 +47,25 @@ type ListBranchesOption struct {
 	Offset int `url:"offset,omitempty"`
 	// Attributes to sort branches by
 	SortBy string `url:"sort_by,omitempty"`
+	// List of attributes to eager load
+	Include []string `url:"include,omitempty,comma"`
 }
 
-// getBranchesResponse represents the response of a call
-// to the Travis CI branches endpoint.
-type getBranchesResponse struct {
+// BranchOption specifies the optional parameters for branch endpoint
+type BranchOption struct {
+	// List of attributes to eager load
+	Include []string `url:"include,omitempty,comma"`
+}
+
+type branchesResponse struct {
 	Branches []*Branch `json:"branches"`
 }
 
 // FindByRepoId fetches a branch based on the provided repository id and branch name
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/branch#find
-func (bs *BranchesService) FindByRepoId(ctx context.Context, repoId uint, branchName string) (*Branch, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/branch/%s", repoId, branchName), nil)
+func (bs *BranchesService) FindByRepoId(ctx context.Context, repoId uint, branchName string, opt *BranchOption) (*Branch, *http.Response, error) {
+	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/branch/%s", repoId, branchName), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -79,8 +87,8 @@ func (bs *BranchesService) FindByRepoId(ctx context.Context, repoId uint, branch
 // FindByRepoSlug fetches a branch based on the provided repository slug and branch name
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/branch#find
-func (bs *BranchesService) FindByRepoSlug(ctx context.Context, repoSlug string, branchName string) (*Branch, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/branch/%s", url.QueryEscape(repoSlug), branchName), nil)
+func (bs *BranchesService) FindByRepoSlug(ctx context.Context, repoSlug string, branchName string, opt *BranchOption) (*Branch, *http.Response, error) {
+	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/branch/%s", url.QueryEscape(repoSlug), branchName), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -102,7 +110,7 @@ func (bs *BranchesService) FindByRepoSlug(ctx context.Context, repoSlug string, 
 // ListByRepoId fetches the branches of a given repository id.
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/branches#find
-func (bs *BranchesService) ListByRepoId(ctx context.Context, repoId uint, opt *ListBranchesOption) ([]*Branch, *http.Response, error) {
+func (bs *BranchesService) ListByRepoId(ctx context.Context, repoId uint, opt *BranchesOption) ([]*Branch, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/branches", repoId), opt)
 	if err != nil {
 		return nil, nil, err
@@ -113,19 +121,19 @@ func (bs *BranchesService) ListByRepoId(ctx context.Context, repoId uint, opt *L
 		return nil, nil, err
 	}
 
-	var getBranchesResponse getBranchesResponse
-	resp, err := bs.client.Do(ctx, req, &getBranchesResponse)
+	var br branchesResponse
+	resp, err := bs.client.Do(ctx, req, &br)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return getBranchesResponse.Branches, resp, err
+	return br.Branches, resp, err
 }
 
 // ListByRepoSlug fetches the branches of a given repository slug.
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/branches#find
-func (bs *BranchesService) ListByRepoSlug(ctx context.Context, repoSlug string, opt *ListBranchesOption) ([]*Branch, *http.Response, error) {
+func (bs *BranchesService) ListByRepoSlug(ctx context.Context, repoSlug string, opt *BranchesOption) ([]*Branch, *http.Response, error) {
 	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/branches", url.QueryEscape(repoSlug)), opt)
 	if err != nil {
 		return nil, nil, err
@@ -136,11 +144,11 @@ func (bs *BranchesService) ListByRepoSlug(ctx context.Context, repoSlug string, 
 		return nil, nil, err
 	}
 
-	var getBranchesResponse getBranchesResponse
-	resp, err := bs.client.Do(ctx, req, &getBranchesResponse)
+	var br branchesResponse
+	resp, err := bs.client.Do(ctx, req, &br)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return getBranchesResponse.Branches, resp, err
+	return br.Branches, resp, err
 }

--- a/branches_integration_test.go
+++ b/branches_integration_test.go
@@ -11,10 +11,13 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func TestBranchesService_Integration_FindByRepoId(t *testing.T) {
-	branch, res, err := integrationClient.Branches.FindByRepoId(context.TODO(), integrationRepoId, "master")
+	opt := BranchOption{Include: []string{"branch.recent_builds"}}
+
+	branch, res, err := integrationClient.Branches.FindByRepoId(context.TODO(), integrationRepoId, "master", &opt)
 
 	if err != nil {
 		t.Fatalf("unexpected error occured: %s", err)
@@ -31,10 +34,16 @@ func TestBranchesService_Integration_FindByRepoId(t *testing.T) {
 	if branch.Repository.Id != integrationRepoId {
 		t.Fatalf("unexpected branch returned: want %d: got %d", integrationRepoId, branch.Repository.Id)
 	}
+
+	if len(branch.RecentBuilds) == 0 {
+		t.Fatal("recent builds is empty")
+	}
 }
 
 func TestBranchesService_Integration_FindByRepoSlug(t *testing.T) {
-	branch, res, err := integrationClient.Branches.FindByRepoSlug(context.TODO(), integrationRepoSlug, "master")
+	opt := BranchOption{Include: []string{"branch.repository"}}
+
+	branch, res, err := integrationClient.Branches.FindByRepoSlug(context.TODO(), integrationRepoSlug, "master", &opt)
 
 	if err != nil {
 		t.Fatalf("unexpected error occured: %s", err)
@@ -51,14 +60,19 @@ func TestBranchesService_Integration_FindByRepoSlug(t *testing.T) {
 	if branch.Repository.Slug != integrationRepoSlug {
 		t.Fatalf("unexpected branch returned: want %s: got %s", integrationRepoSlug, branch.Repository.Slug)
 	}
+
+	if branch.Repository == nil {
+		t.Fatal("repository is empty")
+	}
 }
 
 func TestBranchesService_Integration_ListByRepoId(t *testing.T) {
-	cases := []*ListBranchesOption{
+	cases := []*BranchesOption{
 		{},
 		{Limit: 1},
 		{SortBy: "id"},
 		{Offset: 0},
+		{Include: []string{"branch.recent_builds"}},
 	}
 
 	for i, opt := range cases {
@@ -75,15 +89,18 @@ func TestBranchesService_Integration_ListByRepoId(t *testing.T) {
 		if len(branches) == 0 {
 			t.Fatalf("#%d returned empty branches", i)
 		}
+
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 
 func TestBranchesService_Integration_ListByRepoSlug(t *testing.T) {
-	cases := []*ListBranchesOption{
+	cases := []*BranchesOption{
 		{},
 		{Limit: 1},
 		{SortBy: "id"},
 		{Offset: 0},
+		{Include: []string{"branch.repository"}},
 	}
 
 	for i, opt := range cases {
@@ -100,5 +117,7 @@ func TestBranchesService_Integration_ListByRepoSlug(t *testing.T) {
 		if len(branches) == 0 {
 			t.Fatalf("#%d returned empty branches", i)
 		}
+
+		time.Sleep(5 * time.Millisecond)
 	}
 }

--- a/branches_test.go
+++ b/branches_test.go
@@ -26,10 +26,12 @@ func TestBranchesService_FindByRepoId(t *testing.T) {
 
 	mux.HandleFunc(fmt.Sprintf("/repo/%d/branch/%s", testRepoId, "master"), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
+		testFormValues(t, r, values{"include": "branch.recent_builds"})
 		fmt.Fprint(w, `{"name":"master","repository":{"id":1,"name":"test","slug":"shuheiktgw/test"},"default_branch":true,"exists_on_github":true}`)
 	})
 
-	branch, _, err := client.Branches.FindByRepoId(context.Background(), testRepoId, "master")
+	opt := BranchOption{Include: []string{"branch.recent_builds"}}
+	branch, _, err := client.Branches.FindByRepoId(context.Background(), testRepoId, "master", &opt)
 
 	if err != nil {
 		t.Errorf("Branch.FindByRepoId returned error: %v", err)
@@ -47,10 +49,12 @@ func TestBranchesService_FindByRepoSlug(t *testing.T) {
 
 	mux.HandleFunc(fmt.Sprintf("/repo/%s/branch/%s", testEscapedRepoSlug, "master"), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
+		testFormValues(t, r, values{"include": "branch.recent_builds"})
 		fmt.Fprint(w, `{"name":"master","repository":{"id":1,"name":"test","slug":"shuheiktgw/test"},"default_branch":true,"exists_on_github":true}`)
 	})
 
-	branch, _, err := client.Branches.FindByRepoSlug(context.Background(), testEscapedRepoSlug, "master")
+	opt := BranchOption{Include: []string{"branch.recent_builds"}}
+	branch, _, err := client.Branches.FindByRepoSlug(context.Background(), testEscapedRepoSlug, "master", &opt)
 
 	if err != nil {
 		t.Errorf("Branch.FindByRepoId returned error: %v", err)
@@ -68,11 +72,12 @@ func TestBranchesService_ListByRepoId(t *testing.T) {
 
 	mux.HandleFunc(fmt.Sprintf("/repo/%d/branches", testRepoId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		testFormValues(t, r, values{"exists_on_github": "true", "limit": "50"})
+		testFormValues(t, r, values{"exists_on_github": "true", "limit": "50", "include": "branch.recent_builds"})
 		fmt.Fprint(w, `{"branches": [{"name":"master","repository":{"id":1,"name":"test","slug":"shuheiktgw/test"},"default_branch":true,"exists_on_github":true}]}`)
 	})
 
-	branches, _, err := client.Branches.ListByRepoId(context.Background(), testRepoId, &ListBranchesOption{ExistsOnGithub: true, Limit: 50})
+	opt := BranchesOption{ExistsOnGithub: true, Limit: 50, Include: []string{"branch.recent_builds"}}
+	branches, _, err := client.Branches.ListByRepoId(context.Background(), testRepoId, &opt)
 
 	if err != nil {
 		t.Errorf("Branches.FindByRepoId returned error: %v", err)
@@ -90,11 +95,12 @@ func TestBranchesService_ListByRepoSlug(t *testing.T) {
 
 	mux.HandleFunc(fmt.Sprintf("/repo/%s/branches", testRepoSlug), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		testFormValues(t, r, values{"exists_on_github": "true", "limit": "50"})
+		testFormValues(t, r, values{"exists_on_github": "true", "limit": "50", "include": "branch.recent_builds"})
 		fmt.Fprint(w, `{"branches": [{"name":"master","repository":{"id":1,"name":"test","slug":"shuheiktgw/test"},"default_branch":true,"exists_on_github":true}]}`)
 	})
 
-	branches, _, err := client.Branches.ListByRepoSlug(context.Background(), testRepoSlug, &ListBranchesOption{ExistsOnGithub: true, Limit: 50})
+	opt := BranchesOption{ExistsOnGithub: true, Limit: 50, Include: []string{"branch.recent_builds"}}
+	branches, _, err := client.Branches.ListByRepoSlug(context.Background(), testRepoSlug, &opt)
 
 	if err != nil {
 		t.Errorf("Branches.indByRepoSlug returned error: %v", err)


### PR DESCRIPTION
Fixes to support eager loading on the branches and branch endpoints.

- Add `BranchOption`
- Add `RecentBuilds` props to `Branch` struct
- Rename `ListBranchesOption` -> `BranchesOption`
- Rename `getBranchesResponse` -> `branchesResponse ` 