### PR TITLE
Add a support for eager loading on the jobs and job endpoints

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -54,8 +54,7 @@ type Job struct {
 	*Metadata
 }
 
-// JobsOption is query parameters to one can specify
-// to find jobs
+// JobsOption is query parameters to one can specify to find jobs
 type JobsOption struct {
 	// How many jobs to include in the response
 	Limit int `url:"limit,omitempty"`
@@ -65,9 +64,17 @@ type JobsOption struct {
 	SortBy []string `url:"sort_by,omitempty,comma"`
 	// // Current state of the job
 	State []string `url:"state,omitempty,comma"`
+	// List of attributes to eager load
+	Include []string `url:"include,omitempty,comma"`
 }
 
-type getJobsResponse struct {
+// JobOption is query parameters to one can specify to find job
+type JobOption struct {
+	// List of attributes to eager load
+	Include []string `url:"include,omitempty,comma"`
+}
+
+type jobsResponse struct {
 	Jobs []*Job `json:"jobs"`
 }
 
@@ -94,8 +101,8 @@ const (
 // Find fetches a job based on the provided job id
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/job#find
-func (js *JobsService) Find(ctx context.Context, id uint) (*Job, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/job/%d", id), nil)
+func (js *JobsService) Find(ctx context.Context, id uint, opt *JobOption) (*Job, *http.Response, error) {
+	u, err := urlWithOptions(fmt.Sprintf("/job/%d", id), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -128,13 +135,13 @@ func (js *JobsService) ListByBuild(ctx context.Context, buildId uint) ([]*Job, *
 		return nil, nil, err
 	}
 
-	var getJobsResponse getJobsResponse
-	resp, err := js.client.Do(ctx, req, &getJobsResponse)
+	var jr jobsResponse
+	resp, err := js.client.Do(ctx, req, &jr)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return getJobsResponse.Jobs, resp, err
+	return jr.Jobs, resp, err
 }
 
 // List fetches current user's jobs based on the provided options
@@ -153,13 +160,13 @@ func (js *JobsService) List(ctx context.Context, opt *JobsOption) ([]*Job, *http
 		return nil, nil, err
 	}
 
-	var getJobsResponse getJobsResponse
-	resp, err := js.client.Do(ctx, req, &getJobsResponse)
+	var jr jobsResponse
+	resp, err := js.client.Do(ctx, req, &jr)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return getJobsResponse.Jobs, resp, err
+	return jr.Jobs, resp, err
 }
 
 // Cancel cancels a job based on the provided job id
@@ -176,13 +183,13 @@ func (js *JobsService) Cancel(ctx context.Context, id uint) (*Job, *http.Respons
 		return nil, nil, err
 	}
 
-	var jobResponse jobResponse
-	resp, err := js.client.Do(ctx, req, &jobResponse)
+	var jr jobResponse
+	resp, err := js.client.Do(ctx, req, &jr)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return jobResponse.Job, resp, err
+	return jr.Job, resp, err
 }
 
 // Restart restarts a job based on the provided job id
@@ -199,13 +206,13 @@ func (js *JobsService) Restart(ctx context.Context, id uint) (*Job, *http.Respon
 		return nil, nil, err
 	}
 
-	var jobResponse jobResponse
-	resp, err := js.client.Do(ctx, req, &jobResponse)
+	var jr jobResponse
+	resp, err := js.client.Do(ctx, req, &jr)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return jobResponse.Job, resp, err
+	return jr.Job, resp, err
 }
 
 // Debug restarts a job in debug mode based on the provided job id
@@ -224,11 +231,11 @@ func (js *JobsService) Debug(ctx context.Context, id uint) (*Job, *http.Response
 		return nil, nil, err
 	}
 
-	var jobResponse jobResponse
-	resp, err := js.client.Do(ctx, req, &jobResponse)
+	var jr jobResponse
+	resp, err := js.client.Do(ctx, req, &jr)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return jobResponse.Job, resp, err
+	return jr.Job, resp, err
 }

--- a/jobs_integration_test.go
+++ b/jobs_integration_test.go
@@ -17,7 +17,8 @@ import (
 const buildId = 420907933
 
 func TestJobsService_Integration_Find(t *testing.T) {
-	job, res, err := integrationClient.Jobs.Find(context.TODO(), integrationJobId)
+	opt := JobOption{Include: []string{"job.repository"}}
+	job, res, err := integrationClient.Jobs.Find(context.TODO(), integrationJobId, &opt)
 
 	if err != nil {
 		t.Fatalf("unexpected error occured: %s", err)
@@ -30,6 +31,14 @@ func TestJobsService_Integration_Find(t *testing.T) {
 	if job.Id != integrationJobId {
 		t.Fatalf("unexpected job returned: want job id %d: got job id %d", integrationBuildId, job.Id)
 	}
+
+	if job.Repository.IsMinimal() {
+		t.Fatal("repository is minimal representation")
+	}
+
+	if job.Commit.IsStandard() {
+		t.Fatal("commit is standard representation")
+	}
 }
 
 func TestJobsService_Integration_ListByBuild(t *testing.T) {
@@ -40,7 +49,7 @@ func TestJobsService_Integration_ListByBuild(t *testing.T) {
 	}
 
 	if res.StatusCode != http.StatusOK {
-		t.Fatalf("#invalid http status: %s", res.Status)
+		t.Fatalf("invalid http status: %s", res.Status)
 	}
 
 	if len(jobs) == 0 {

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -21,10 +21,12 @@ func TestJobsService_Find(t *testing.T) {
 
 	mux.HandleFunc(fmt.Sprintf("/job/%d", testJobId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
+		testFormValues(t, r, values{"include": "job.commit"})
 		fmt.Fprint(w, `{"id":1,"allow_failure":true,"number":"1","state":"created"}`)
 	})
 
-	job, _, err := client.Jobs.Find(context.Background(), testJobId)
+	opt := JobOption{Include: []string{"job.commit"}}
+	job, _, err := client.Jobs.Find(context.Background(), testJobId, &opt)
 
 	if err != nil {
 		t.Errorf("Job.Find returned error: %v", err)
@@ -63,11 +65,12 @@ func TestJobsService_List(t *testing.T) {
 
 	mux.HandleFunc("/jobs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		testFormValues(t, r, values{"limit": "50", "state": "created,queued"})
+		testFormValues(t, r, values{"limit": "50", "state": "created,queued", "include": "job.commit"})
 		fmt.Fprint(w, `{"jobs":[{"id":1,"allow_failure":true,"number":"1","state":"created"}]}`)
 	})
 
-	job, _, err := client.Jobs.List(context.Background(), &JobsOption{Limit: 50, State: []string{"created", "queued"}})
+	opt := JobsOption{Limit: 50, State: []string{"created", "queued"}, Include: []string{"job.commit"}}
+	job, _, err := client.Jobs.List(context.Background(), &opt)
 
 	if err != nil {
 		t.Errorf("Jobs.List returned error: %v", err)


### PR DESCRIPTION
Fixes to support eager loading on the jobs and job endpoints.

- Add `JobOption`
- Add `Include` prop to `JobsOption`
- Rename `getJobsResponse` -> `jobsResponse `