### PR TITLE
Add support for eager loading on the owner endpoint

### DIFF
--- a/owners.go
+++ b/owners.go
@@ -33,15 +33,25 @@ type Owner struct {
 	AvatarUrl string `json:"avatar_url"`
 	// Whether or not the owner has an education account
 	Education bool `json:"education"`
+	// Repositories belonging to this account
+	Repositories []*Repository `json:"repositories"`
+	// Installation belonging to the owner
+	Installation *Installation `json:"installation"`
 	*Metadata
+}
+
+// OwnerOption specifies the optional parameters for owner endpoint
+type OwnerOption struct {
+	// List of attributes to eager load
+	Include []string `url:"include,omitempty,comma"`
 }
 
 // Find fetches a owner based on the provided login
 // Login is user or organization login set on GitHub
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/owner#find
-func (os *OwnerService) FindByLogin(ctx context.Context, login string) (*Owner, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/owner/%s", login), nil)
+func (os *OwnerService) FindByLogin(ctx context.Context, login string, opt *OwnerOption) (*Owner, *http.Response, error) {
+	u, err := urlWithOptions(fmt.Sprintf("/owner/%s", login), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -63,8 +73,8 @@ func (os *OwnerService) FindByLogin(ctx context.Context, login string) (*Owner, 
 // Find fetches a owner based on the provided GitHub id
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/owner#find
-func (os *OwnerService) FindByGitHubId(ctx context.Context, githubId uint) (*Owner, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/owner/github_id/%d", githubId), nil)
+func (os *OwnerService) FindByGitHubId(ctx context.Context, githubId uint, opt *OwnerOption) (*Owner, *http.Response, error) {
+	u, err := urlWithOptions(fmt.Sprintf("/owner/github_id/%d", githubId), opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/owners_integration_test.go
+++ b/owners_integration_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 func TestOwnerService_Integration_FindByLogin(t *testing.T) {
-	owner, res, err := integrationClient.Owner.FindByLogin(context.TODO(), integrationGitHubOwner)
+	opt := OwnerOption{Include: []string{"owner.repositories"}}
+	owner, res, err := integrationClient.Owner.FindByLogin(context.TODO(), integrationGitHubOwner, &opt)
 
 	if err != nil {
 		t.Fatalf("unexpected error occured: %s", err)
@@ -27,10 +28,19 @@ func TestOwnerService_Integration_FindByLogin(t *testing.T) {
 	if owner.Login != integrationGitHubOwner {
 		t.Fatalf("unexpected owner returned: want %s: got %s", integrationGitHubOwner, owner.Login)
 	}
+
+	if len(owner.Repositories) == 0 {
+		t.Fatal("repositories are empty")
+	}
+
+	if !owner.Repositories[0].IsStandard() {
+		t.Fatal("repository is not in a standard representation")
+	}
 }
 
 func TestOwnerService_Integration_FindByGitHubId(t *testing.T) {
-	owner, res, err := integrationClient.Owner.FindByGitHubId(context.TODO(), integrationGitHubOwnerId)
+	opt := OwnerOption{Include: []string{"owner.installation"}}
+	owner, res, err := integrationClient.Owner.FindByGitHubId(context.TODO(), integrationGitHubOwnerId, &opt)
 
 	if err != nil {
 		t.Fatalf("unexpected error occured: %s", err)

--- a/owners_test.go
+++ b/owners_test.go
@@ -19,10 +19,12 @@ func TestOwnerService_FindByLogin(t *testing.T) {
 
 	mux.HandleFunc("/owner/shuheiktgw", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
+		testFormValues(t, r, values{"include": "owner.repositories"})
 		fmt.Fprint(w, `{"id":1,"login":"shuheiktgw","github_id":1}`)
 	})
 
-	owner, _, err := client.Owner.FindByLogin(context.Background(), "shuheiktgw")
+	opt := OwnerOption{Include: []string{"owner.repositories"}}
+	owner, _, err := client.Owner.FindByLogin(context.Background(), "shuheiktgw", &opt)
 
 	if err != nil {
 		t.Errorf("Owner.FindByLogin returned error: %v", err)
@@ -40,10 +42,12 @@ func TestOwnerService_FindByGitHubId(t *testing.T) {
 
 	mux.HandleFunc("/owner/github_id/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
+		testFormValues(t, r, values{"include": "owner.installation"})
 		fmt.Fprint(w, `{"id":1,"login":"shuheiktgw","github_id":1}`)
 	})
 
-	owner, _, err := client.Owner.FindByGitHubId(context.Background(), 1)
+	opt := OwnerOption{Include: []string{"owner.installation"}}
+	owner, _, err := client.Owner.FindByGitHubId(context.Background(), 1, &opt)
 
 	if err != nil {
 		t.Errorf("Owner.FindByGitHubId returned error: %v", err)


### PR DESCRIPTION
- Rename `owner.go` -> `owners.go`.
- Add `OwnerOption` struct to support eager loading on the owner endpoint.