### PR TITLE
Support eager loading on broadcast endpoint

### DIFF
--- a/broadcasts.go
+++ b/broadcasts.go
@@ -39,11 +39,13 @@ type Broadcast struct {
 type BroadcastsOption struct {
 	// Filters broadcasts by whether or not the broadcast should still be displayed
 	Active bool `url:"active"`
+	// List of attributes to eager load
+	Include []string `url:"include,omitempty,comma"`
 }
 
-// getBroadcastsResponse represents a response
+// broadcastsResponse represents a response
 // from broadcast endpoints
-type getBroadcastsResponse struct {
+type broadcastsResponse struct {
 	Broadcasts []*Broadcast `json:"broadcasts,omitempty"`
 }
 
@@ -61,11 +63,11 @@ func (bs *BroadcastsService) List(ctx context.Context, opt *BroadcastsOption) ([
 		return nil, nil, err
 	}
 
-	var getBroadcastsResponse getBroadcastsResponse
-	resp, err := bs.client.Do(ctx, req, &getBroadcastsResponse)
+	var br broadcastsResponse
+	resp, err := bs.client.Do(ctx, req, &br)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return getBroadcastsResponse.Broadcasts, resp, err
+	return br.Broadcasts, resp, err
 }

--- a/broadcasts_integration_test.go
+++ b/broadcasts_integration_test.go
@@ -18,7 +18,7 @@ func TestBroadcastsService_Integration_List(t *testing.T) {
 	cases := []*BroadcastsOption{
 		nil,
 		{Active: true},
-		{Active: false},
+		{Active: false, Include: []string{"broadcast.recipient"}},
 	}
 
 	for i, opt := range cases {

--- a/broadcasts_test.go
+++ b/broadcasts_test.go
@@ -19,11 +19,11 @@ func TestBroadcastsService_List(t *testing.T) {
 
 	mux.HandleFunc("/broadcasts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
-		testFormValues(t, r, values{"active": "true"})
+		testFormValues(t, r, values{"active": "true", "include": "broadcast.recipient"})
 		fmt.Fprint(w, `{"broadcasts": [{"id":125,"message":"We just switched the default image for","active":true,"created_at":"2014-11-19T14:39:51Z"}]}`)
 	})
 
-	broadcasts, _, err := client.Broadcasts.List(context.Background(), &BroadcastsOption{Active: true})
+	broadcasts, _, err := client.Broadcasts.List(context.Background(), &BroadcastsOption{Active: true, Include: []string{"broadcast.recipient"}})
 
 	if err != nil {
 		t.Errorf("Broadcasts.List returned error: %v", err)


### PR DESCRIPTION
- Rename `getBroadcastsResponse` -> `broadcastsResponse`.
- Add `Include` option to `BroadcastsOption`.