### PR TITLE
Removes prefix slashes from the API paths

### DIFF
--- a/active.go
+++ b/active.go
@@ -33,7 +33,7 @@ type ActiveOption struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/active#for_owner
 func (as *ActiveService) FindByOwner(ctx context.Context, owner string, opt *ActiveOption) ([]*Build, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/owner/%s/active", owner), opt)
+	u, err := urlWithOptions(fmt.Sprintf("owner/%s/active", owner), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -56,7 +56,7 @@ func (as *ActiveService) FindByOwner(ctx context.Context, owner string, opt *Act
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/active#for_owner
 func (as *ActiveService) FindByGitHubId(ctx context.Context, githubId uint, opt *ActiveOption) ([]*Build, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/owner/github_id/%d/active", githubId), opt)
+	u, err := urlWithOptions(fmt.Sprintf("owner/github_id/%d/active", githubId), opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/beta_features.go
+++ b/beta_features.go
@@ -44,7 +44,7 @@ type betaFeaturesResponse struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/beta_features#find
 func (bs *BetaFeaturesService) List(ctx context.Context, userId uint) ([]*BetaFeature, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/user/%d/beta_features", userId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("user/%d/beta_features", userId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -67,7 +67,7 @@ func (bs *BetaFeaturesService) List(ctx context.Context, userId uint) ([]*BetaFe
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/beta_feature#update
 func (bs *BetaFeaturesService) Update(ctx context.Context, userId uint, id uint, enabled bool) (*BetaFeature, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/user/%d/beta_feature/%d", userId, id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("user/%d/beta_feature/%d", userId, id), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -90,7 +90,7 @@ func (bs *BetaFeaturesService) Update(ctx context.Context, userId uint, id uint,
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/beta_feature#delete
 func (bs *BetaFeaturesService) Delete(ctx context.Context, userId uint, id uint) (*BetaFeature, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/user/%d/beta_feature/%d", userId, id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("user/%d/beta_feature/%d", userId, id), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/beta_migration_requests.go
+++ b/beta_migration_requests.go
@@ -58,7 +58,7 @@ type betaMigrationRequestsResponse struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/beta_migration_requests#find
 func (bs *BetaMigrationRequestsService) List(ctx context.Context, userId uint, opt *BetaMigrationRequestsOption) ([]*BetaMigrationRequest, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/user/%d/beta_migration_requests", userId), opt)
+	u, err := urlWithOptions(fmt.Sprintf("user/%d/beta_migration_requests", userId), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -81,7 +81,7 @@ func (bs *BetaMigrationRequestsService) List(ctx context.Context, userId uint, o
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/beta_migration_request#create
 func (bs *BetaMigrationRequestsService) Create(ctx context.Context, userId uint, request *BetaMigrationRequestBody) (*BetaMigrationRequest, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/user/%d/beta_migration_request", userId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("user/%d/beta_migration_request", userId), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/branches.go
+++ b/branches.go
@@ -65,7 +65,7 @@ type branchesResponse struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/branch#find
 func (bs *BranchesService) FindByRepoId(ctx context.Context, repoId uint, branchName string, opt *BranchOption) (*Branch, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/branch/%s", repoId, branchName), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/branch/%s", repoId, branchName), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -88,7 +88,7 @@ func (bs *BranchesService) FindByRepoId(ctx context.Context, repoId uint, branch
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/branch#find
 func (bs *BranchesService) FindByRepoSlug(ctx context.Context, repoSlug string, branchName string, opt *BranchOption) (*Branch, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/branch/%s", url.QueryEscape(repoSlug), branchName), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/branch/%s", url.QueryEscape(repoSlug), branchName), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -111,7 +111,7 @@ func (bs *BranchesService) FindByRepoSlug(ctx context.Context, repoSlug string, 
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/branches#find
 func (bs *BranchesService) ListByRepoId(ctx context.Context, repoId uint, opt *BranchesOption) ([]*Branch, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/branches", repoId), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/branches", repoId), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -134,7 +134,7 @@ func (bs *BranchesService) ListByRepoId(ctx context.Context, repoId uint, opt *B
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/branches#find
 func (bs *BranchesService) ListByRepoSlug(ctx context.Context, repoSlug string, opt *BranchesOption) ([]*Branch, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/branches", url.QueryEscape(repoSlug)), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/branches", url.QueryEscape(repoSlug)), opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/broadcasts.go
+++ b/broadcasts.go
@@ -53,7 +53,7 @@ type broadcastsResponse struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/broadcasts#for_current_user
 func (bs *BroadcastsService) List(ctx context.Context, opt *BroadcastsOption) ([]*Broadcast, *http.Response, error) {
-	u, err := urlWithOptions("/broadcasts", opt)
+	u, err := urlWithOptions("broadcasts", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/builds.go
+++ b/builds.go
@@ -140,7 +140,7 @@ const (
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/build#find
 func (bs *BuildsService) Find(ctx context.Context, id uint, opt *BuildOption) (*Build, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/build/%d", id), opt)
+	u, err := urlWithOptions(fmt.Sprintf("build/%d", id), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -163,7 +163,7 @@ func (bs *BuildsService) Find(ctx context.Context, id uint, opt *BuildOption) (*
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/builds#for_current_user
 func (bs *BuildsService) List(ctx context.Context, opt *BuildsOption) ([]*Build, *http.Response, error) {
-	u, err := urlWithOptions("/builds", opt)
+	u, err := urlWithOptions("builds", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -186,7 +186,7 @@ func (bs *BuildsService) List(ctx context.Context, opt *BuildsOption) ([]*Build,
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/builds#find
 func (bs *BuildsService) ListByRepoId(ctx context.Context, repoId uint, opt *BuildsByRepoOption) ([]*Build, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/builds", repoId), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/builds", repoId), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -209,7 +209,7 @@ func (bs *BuildsService) ListByRepoId(ctx context.Context, repoId uint, opt *Bui
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/builds#find
 func (bs *BuildsService) ListByRepoSlug(ctx context.Context, repoSlug string, opt *BuildsByRepoOption) ([]*Build, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/builds", url.QueryEscape(repoSlug)), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/builds", url.QueryEscape(repoSlug)), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -232,7 +232,7 @@ func (bs *BuildsService) ListByRepoSlug(ctx context.Context, repoSlug string, op
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/build#cancel
 func (bs *BuildsService) Cancel(ctx context.Context, id uint) (*Build, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/build/%d/cancel", id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("build/%d/cancel", id), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -255,7 +255,7 @@ func (bs *BuildsService) Cancel(ctx context.Context, id uint) (*Build, *http.Res
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/build#restart
 func (bs *BuildsService) Restart(ctx context.Context, id uint) (*Build, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/build/%d/restart", id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("build/%d/restart", id), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/caches.go
+++ b/caches.go
@@ -39,7 +39,7 @@ type cachesResponse struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/caches#find
 func (cs *CachesService) ListByRepoId(ctx context.Context, repoId uint) ([]*Cache, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/caches", repoId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/caches", repoId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -62,7 +62,7 @@ func (cs *CachesService) ListByRepoId(ctx context.Context, repoId uint) ([]*Cach
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/caches#find
 func (cs *CachesService) ListByRepoSlug(ctx context.Context, repoSlug string) ([]*Cache, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/caches", url.QueryEscape(repoSlug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/caches", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -85,7 +85,7 @@ func (cs *CachesService) ListByRepoSlug(ctx context.Context, repoSlug string) ([
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/caches#delete
 func (cs *CachesService) DeleteByRepoId(ctx context.Context, repoId uint) ([]*Cache, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/caches", repoId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/caches", repoId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -108,7 +108,7 @@ func (cs *CachesService) DeleteByRepoId(ctx context.Context, repoId uint) ([]*Ca
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/caches#delete
 func (cs *CachesService) DeleteByRepoSlug(ctx context.Context, repoSlug string) ([]*Cache, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/caches", url.QueryEscape(repoSlug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/caches", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/crons.go
+++ b/crons.go
@@ -86,7 +86,7 @@ const (
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/cron#find
 func (cs *CronsService) Find(ctx context.Context, id uint, opt *CronOption) (*Cron, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/cron/%d", id), opt)
+	u, err := urlWithOptions(fmt.Sprintf("cron/%d", id), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -109,7 +109,7 @@ func (cs *CronsService) Find(ctx context.Context, id uint, opt *CronOption) (*Cr
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/cron#for_branch
 func (cs *CronsService) FindByRepoId(ctx context.Context, repoId uint, branch string, opt *CronOption) (*Cron, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/branch/%s/cron", repoId, branch), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/branch/%s/cron", repoId, branch), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -132,7 +132,7 @@ func (cs *CronsService) FindByRepoId(ctx context.Context, repoId uint, branch st
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/cron#for_branch
 func (cs *CronsService) FindByRepoSlug(ctx context.Context, repoSlug string, branch string, opt *CronOption) (*Cron, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/branch/%s/cron", url.QueryEscape(repoSlug), branch), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/branch/%s/cron", url.QueryEscape(repoSlug), branch), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -155,7 +155,7 @@ func (cs *CronsService) FindByRepoSlug(ctx context.Context, repoSlug string, bra
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/crons#for_repository
 func (cs *CronsService) ListByRepoId(ctx context.Context, repoId uint, opt *CronsOption) ([]*Cron, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/crons", repoId), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/crons", repoId), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -178,7 +178,7 @@ func (cs *CronsService) ListByRepoId(ctx context.Context, repoId uint, opt *Cron
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/crons#for_repository
 func (cs *CronsService) ListByRepoSlug(ctx context.Context, repoSlug string, opt *CronsOption) ([]*Cron, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/crons", url.QueryEscape(repoSlug)), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/crons", url.QueryEscape(repoSlug)), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -201,7 +201,7 @@ func (cs *CronsService) ListByRepoSlug(ctx context.Context, repoSlug string, opt
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/cron#create
 func (cs *CronsService) CreateByRepoId(ctx context.Context, repoId uint, branchName string, cron *CronBody) (*Cron, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/branch/%s/cron", repoId, branchName), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/branch/%s/cron", repoId, branchName), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -224,7 +224,7 @@ func (cs *CronsService) CreateByRepoId(ctx context.Context, repoId uint, branchN
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/cron#create
 func (cs *CronsService) CreateByRepoSlug(ctx context.Context, repoSlug string, branchName string, cron *CronBody) (*Cron, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/branch/%s/cron", url.QueryEscape(repoSlug), branchName), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/branch/%s/cron", url.QueryEscape(repoSlug), branchName), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -247,7 +247,7 @@ func (cs *CronsService) CreateByRepoSlug(ctx context.Context, repoSlug string, b
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/cron#delete
 func (cs *CronsService) Delete(ctx context.Context, id uint) (*http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/cron/%d", id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("cron/%d", id), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/email_subscriptions.go
+++ b/email_subscriptions.go
@@ -22,7 +22,7 @@ type EmailSubscriptionsService struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/email_subscription#resubscribe
 func (es *EmailSubscriptionsService) SubscribeByRepoId(ctx context.Context, repoId uint) (*http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/email_subscription", repoId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/email_subscription", repoId), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func (es *EmailSubscriptionsService) SubscribeByRepoId(ctx context.Context, repo
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/email_subscription#resubscribe
 func (es *EmailSubscriptionsService) SubscribeByRepoSlug(ctx context.Context, repoSlug string) (*http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/email_subscription", url.QueryEscape(repoSlug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/email_subscription", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (es *EmailSubscriptionsService) SubscribeByRepoSlug(ctx context.Context, re
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/email_subscription#unsubscribe
 func (es *EmailSubscriptionsService) UnsubscribeByRepoId(ctx context.Context, repoId uint) (*http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/email_subscription", repoId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/email_subscription", repoId), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func (es *EmailSubscriptionsService) UnsubscribeByRepoId(ctx context.Context, re
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/email_subscription#unsubscribe
 func (es *EmailSubscriptionsService) UnsubscribeByRepoSlug(ctx context.Context, repoSlug string) (*http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/email_subscription", url.QueryEscape(repoSlug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/email_subscription", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/env_vars.go
+++ b/env_vars.go
@@ -54,7 +54,7 @@ type envVarsResponse struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/env_var#find
 func (es *EnvVarsService) FindByRepoId(ctx context.Context, repoId uint, id string) (*EnvVar, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/env_var/%s", repoId, id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/env_var/%s", repoId, id), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -77,7 +77,7 @@ func (es *EnvVarsService) FindByRepoId(ctx context.Context, repoId uint, id stri
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/env_var#find
 func (es *EnvVarsService) FindByRepoSlug(ctx context.Context, repoSlug string, id string) (*EnvVar, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/env_var/%s", url.QueryEscape(repoSlug), id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/env_var/%s", url.QueryEscape(repoSlug), id), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -100,7 +100,7 @@ func (es *EnvVarsService) FindByRepoSlug(ctx context.Context, repoSlug string, i
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/env_vars#for_repository
 func (es *EnvVarsService) ListByRepoId(ctx context.Context, repoId uint) ([]*EnvVar, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/env_vars", repoId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/env_vars", repoId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -123,7 +123,7 @@ func (es *EnvVarsService) ListByRepoId(ctx context.Context, repoId uint) ([]*Env
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/env_vars#for_repository
 func (es *EnvVarsService) ListByRepoSlug(ctx context.Context, repoSlug string) ([]*EnvVar, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/env_vars", url.QueryEscape(repoSlug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/env_vars", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -146,7 +146,7 @@ func (es *EnvVarsService) ListByRepoSlug(ctx context.Context, repoSlug string) (
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/env_vars#create
 func (es *EnvVarsService) CreateByRepoId(ctx context.Context, repoId uint, envVar *EnvVarBody) (*EnvVar, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/env_vars", repoId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/env_vars", repoId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -169,7 +169,7 @@ func (es *EnvVarsService) CreateByRepoId(ctx context.Context, repoId uint, envVa
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/env_vars#create
 func (es *EnvVarsService) CreateByRepoSlug(ctx context.Context, repoSlug string, envVar *EnvVarBody) (*EnvVar, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/env_vars", url.QueryEscape(repoSlug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/env_vars", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -192,7 +192,7 @@ func (es *EnvVarsService) CreateByRepoSlug(ctx context.Context, repoSlug string,
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/env_var#update
 func (es *EnvVarsService) UpdateByRepoId(ctx context.Context, repoId uint, id string, envVar *EnvVarBody) (*EnvVar, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/env_var/%s", repoId, id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/env_var/%s", repoId, id), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -215,7 +215,7 @@ func (es *EnvVarsService) UpdateByRepoId(ctx context.Context, repoId uint, id st
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/env_var#update
 func (es *EnvVarsService) UpdateByRepoSlug(ctx context.Context, repoSlug string, id string, envVar *EnvVarBody) (*EnvVar, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/env_var/%s", url.QueryEscape(repoSlug), id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/env_var/%s", url.QueryEscape(repoSlug), id), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -238,7 +238,7 @@ func (es *EnvVarsService) UpdateByRepoSlug(ctx context.Context, repoSlug string,
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/env_var#delete
 func (es *EnvVarsService) DeleteByRepoId(ctx context.Context, repoId uint, id string) (*http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/env_var/%s", repoId, id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/env_var/%s", repoId, id), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -260,7 +260,7 @@ func (es *EnvVarsService) DeleteByRepoId(ctx context.Context, repoId uint, id st
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/env_var#delete
 func (es *EnvVarsService) DeleteByRepoSlug(ctx context.Context, repoSlug string, id string) (*http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/env_var/%s", url.QueryEscape(repoSlug), id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/env_var/%s", url.QueryEscape(repoSlug), id), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/installatios.go
+++ b/installatios.go
@@ -40,7 +40,7 @@ type InstallationOption struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/installation#find
 func (is *InstallationsService) Find(ctx context.Context, id uint, opt *InstallationOption) (*Installation, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/installation/%d", id), opt)
+	u, err := urlWithOptions(fmt.Sprintf("installation/%d", id), opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/jobs.go
+++ b/jobs.go
@@ -102,7 +102,7 @@ const (
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/job#find
 func (js *JobsService) Find(ctx context.Context, id uint, opt *JobOption) (*Job, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/job/%d", id), opt)
+	u, err := urlWithOptions(fmt.Sprintf("job/%d", id), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -125,7 +125,7 @@ func (js *JobsService) Find(ctx context.Context, id uint, opt *JobOption) (*Job,
 //
 // Travis CI API docs: https://developer.travis-ci.csom/resource/jobs#find
 func (js *JobsService) ListByBuild(ctx context.Context, buildId uint) ([]*Job, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/build/%d/jobs", buildId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("build/%d/jobs", buildId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -150,7 +150,7 @@ func (js *JobsService) ListByBuild(ctx context.Context, buildId uint) ([]*Job, *
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/jobs#find
 func (js *JobsService) List(ctx context.Context, opt *JobsOption) ([]*Job, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/jobs"), opt)
+	u, err := urlWithOptions(fmt.Sprintf("jobs"), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -173,7 +173,7 @@ func (js *JobsService) List(ctx context.Context, opt *JobsOption) ([]*Job, *http
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/job#cancel
 func (js *JobsService) Cancel(ctx context.Context, id uint) (*Job, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/job/%d/cancel", id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("job/%d/cancel", id), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -196,7 +196,7 @@ func (js *JobsService) Cancel(ctx context.Context, id uint) (*Job, *http.Respons
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/job#restart
 func (js *JobsService) Restart(ctx context.Context, id uint) (*Job, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/job/%d/restart", id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("job/%d/restart", id), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -221,7 +221,7 @@ func (js *JobsService) Restart(ctx context.Context, id uint) (*Job, *http.Respon
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/job#debug
 func (js *JobsService) Debug(ctx context.Context, id uint) (*Job, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/job/%d/debug", id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("job/%d/debug", id), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/key_pair.go
+++ b/key_pair.go
@@ -50,7 +50,7 @@ type KeyPair struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/key_pair#find
 func (ks *KeyPairService) FindByRepoId(ctx context.Context, repoId uint) (*KeyPair, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/key_pair", repoId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/key_pair", repoId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -73,7 +73,7 @@ func (ks *KeyPairService) FindByRepoId(ctx context.Context, repoId uint) (*KeyPa
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/key_pair#find
 func (ks *KeyPairService) FindByRepoSlug(ctx context.Context, repoSlug string) (*KeyPair, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/key_pair", url.QueryEscape(repoSlug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/key_pair", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -96,7 +96,7 @@ func (ks *KeyPairService) FindByRepoSlug(ctx context.Context, repoSlug string) (
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/key_pair#create
 func (ks *KeyPairService) CreateByRepoId(ctx context.Context, repoId uint, keyPair *KeyPairBody) (*KeyPair, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/key_pair", repoId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/key_pair", repoId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -119,7 +119,7 @@ func (ks *KeyPairService) CreateByRepoId(ctx context.Context, repoId uint, keyPa
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/key_pair#create
 func (ks *KeyPairService) CreateByRepoSlug(ctx context.Context, repoSlug string, keyPair *KeyPairBody) (*KeyPair, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/key_pair", url.QueryEscape(repoSlug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/key_pair", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -142,7 +142,7 @@ func (ks *KeyPairService) CreateByRepoSlug(ctx context.Context, repoSlug string,
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/key_pair#update
 func (ks *KeyPairService) UpdateByRepoId(ctx context.Context, repoId uint, keyPair *KeyPairBody) (*KeyPair, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/key_pair", repoId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/key_pair", repoId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -165,7 +165,7 @@ func (ks *KeyPairService) UpdateByRepoId(ctx context.Context, repoId uint, keyPa
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/key_pair#update
 func (ks *KeyPairService) UpdateByRepoSlug(ctx context.Context, repoSlug string, keyPair *KeyPairBody) (*KeyPair, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/key_pair", url.QueryEscape(repoSlug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/key_pair", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -188,7 +188,7 @@ func (ks *KeyPairService) UpdateByRepoSlug(ctx context.Context, repoSlug string,
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/key_pair#delete
 func (ks *KeyPairService) DeleteByRepoId(ctx context.Context, repoId uint) (*http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/key_pair", repoId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/key_pair", repoId), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +210,7 @@ func (ks *KeyPairService) DeleteByRepoId(ctx context.Context, repoId uint) (*htt
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/key_pair#delete
 func (ks *KeyPairService) DeleteByRepoSlug(ctx context.Context, repoSlug string) (*http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/key_pair", url.QueryEscape(repoSlug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/key_pair", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func (ks *KeyPairService) DeleteByRepoSlug(ctx context.Context, repoSlug string)
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/key_pair_generated#find
 func (ks *GeneratedKeyPairService) FindByRepoId(ctx context.Context, repoId uint) (*KeyPair, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/key_pair/generated", repoId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/key_pair/generated", repoId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -255,7 +255,7 @@ func (ks *GeneratedKeyPairService) FindByRepoId(ctx context.Context, repoId uint
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/key_pair_generated#find
 func (ks *GeneratedKeyPairService) FindByRepoSlug(ctx context.Context, repoSlug string) (*KeyPair, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/key_pair/generated", url.QueryEscape(repoSlug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/key_pair/generated", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -278,7 +278,7 @@ func (ks *GeneratedKeyPairService) FindByRepoSlug(ctx context.Context, repoSlug 
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/key_pair_generated#create
 func (ks *GeneratedKeyPairService) CreateByRepoId(ctx context.Context, repoId uint) (*KeyPair, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/key_pair/generated", repoId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/key_pair/generated", repoId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -301,7 +301,7 @@ func (ks *GeneratedKeyPairService) CreateByRepoId(ctx context.Context, repoId ui
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/key_pair_generated#create
 func (ks *GeneratedKeyPairService) CreateByRepoSlug(ctx context.Context, repoSlug string) (*KeyPair, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/key_pair/generated", url.QueryEscape(repoSlug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/key_pair/generated", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lint.go
+++ b/lint.go
@@ -38,7 +38,7 @@ type lintResponse struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/lint#lint
 func (es *LintService) Lint(ctx context.Context, yml *TravisYml) ([]*Warning, *http.Response, error) {
-	u, err := urlWithOptions("/lint", nil)
+	u, err := urlWithOptions("lint", nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/logs.go
+++ b/logs.go
@@ -39,7 +39,7 @@ type LogPart struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/log#find
 func (ls *LogsService) FindByJobId(ctx context.Context, jobId uint) (*Log, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/job/%d/log", jobId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("job/%d/log", jobId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -62,7 +62,7 @@ func (ls *LogsService) FindByJobId(ctx context.Context, jobId uint) (*Log, *http
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/log#delete
 func (ls *LogsService) DeleteByJobId(ctx context.Context, jobId uint) (*Log, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/job/%d/log", jobId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("job/%d/log", jobId), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/messages.go
+++ b/messages.go
@@ -54,7 +54,7 @@ type messagesResponse struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/messages#for_request
 func (ms *MessagesService) ListByRepoId(ctx context.Context, repoId uint, requestId uint, opt *MessagesOption) ([]*Message, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/request/%d/messages", repoId, requestId), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/request/%d/messages", repoId, requestId), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -77,7 +77,7 @@ func (ms *MessagesService) ListByRepoId(ctx context.Context, repoId uint, reques
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/messages#for_request
 func (ms *MessagesService) ListByRepoSlug(ctx context.Context, repoSlug string, requestId uint, opt *MessagesOption) ([]*Message, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/request/%d/messages", url.QueryEscape(repoSlug), requestId), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/request/%d/messages", url.QueryEscape(repoSlug), requestId), opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/organizations.go
+++ b/organizations.go
@@ -68,7 +68,7 @@ type organizationsResponse struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/organization#find
 func (os *OrganizationsService) Find(ctx context.Context, id uint, opt *OrganizationOption) (*Organization, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/org/%d", id), opt)
+	u, err := urlWithOptions(fmt.Sprintf("org/%d", id), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -91,7 +91,7 @@ func (os *OrganizationsService) Find(ctx context.Context, id uint, opt *Organiza
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/organizations#for_current_user
 func (os *OrganizationsService) List(ctx context.Context, opt *OrganizationsOption) ([]*Organization, *http.Response, error) {
-	u, err := urlWithOptions("/orgs", opt)
+	u, err := urlWithOptions("orgs", opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/owners.go
+++ b/owners.go
@@ -51,7 +51,7 @@ type OwnerOption struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/owner#find
 func (os *OwnerService) FindByLogin(ctx context.Context, login string, opt *OwnerOption) (*Owner, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/owner/%s", login), opt)
+	u, err := urlWithOptions(fmt.Sprintf("owner/%s", login), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -74,7 +74,7 @@ func (os *OwnerService) FindByLogin(ctx context.Context, login string, opt *Owne
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/owner#find
 func (os *OwnerService) FindByGitHubId(ctx context.Context, githubId uint, opt *OwnerOption) (*Owner, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/owner/github_id/%d", githubId), opt)
+	u, err := urlWithOptions(fmt.Sprintf("owner/github_id/%d", githubId), opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/preferences.go
+++ b/preferences.go
@@ -45,7 +45,7 @@ type preferencesResponse struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/preference#find
 func (ps *PreferencesService) Find(ctx context.Context, name string) (*Preference, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/preference/%s", name), nil)
+	u, err := urlWithOptions(fmt.Sprintf("preference/%s", name), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -68,7 +68,7 @@ func (ps *PreferencesService) Find(ctx context.Context, name string) (*Preferenc
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/preferences#for_user
 func (ps *PreferencesService) List(ctx context.Context) ([]*Preference, *http.Response, error) {
-	u, err := urlWithOptions("/preferences", nil)
+	u, err := urlWithOptions("preferences", nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -92,7 +92,7 @@ func (ps *PreferencesService) List(ctx context.Context) ([]*Preference, *http.Re
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/preference#update
 func (ps *PreferencesService) Update(ctx context.Context, preference *PreferenceBody) (*Preference, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/preference/%s", preference.Name), nil)
+	u, err := urlWithOptions(fmt.Sprintf("preference/%s", preference.Name), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/repositories.go
+++ b/repositories.go
@@ -92,7 +92,7 @@ type repositoriesResponse struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/repositories#for_current_user
 func (rs *RepositoriesService) List(ctx context.Context, opt *RepositoriesOption) ([]*Repository, *http.Response, error) {
-	u, err := urlWithOptions("/repos", opt)
+	u, err := urlWithOptions("repos", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -115,7 +115,7 @@ func (rs *RepositoriesService) List(ctx context.Context, opt *RepositoriesOption
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/repositories#for_owner
 func (rs *RepositoriesService) ListByOwner(ctx context.Context, owner string, opt *RepositoriesOption) ([]*Repository, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/owner/%s/repos", owner), opt)
+	u, err := urlWithOptions(fmt.Sprintf("owner/%s/repos", owner), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -138,7 +138,7 @@ func (rs *RepositoriesService) ListByOwner(ctx context.Context, owner string, op
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/repositories#for_owner
 func (rs *RepositoriesService) ListByGitHubId(ctx context.Context, id uint, opt *RepositoriesOption) ([]*Repository, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/owner/github_id/%d/repos", id), opt)
+	u, err := urlWithOptions(fmt.Sprintf("owner/github_id/%d/repos", id), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -161,7 +161,7 @@ func (rs *RepositoriesService) ListByGitHubId(ctx context.Context, id uint, opt 
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/repository#find
 func (rs *RepositoriesService) Find(ctx context.Context, slug string, opt *RepositoryOption) (*Repository, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s", url.QueryEscape(slug)), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s", url.QueryEscape(slug)), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -184,7 +184,7 @@ func (rs *RepositoriesService) Find(ctx context.Context, slug string, opt *Repos
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/repository#activate
 func (rs *RepositoriesService) Activate(ctx context.Context, slug string) (*Repository, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/activate", url.QueryEscape(slug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/activate", url.QueryEscape(slug)), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -207,7 +207,7 @@ func (rs *RepositoriesService) Activate(ctx context.Context, slug string) (*Repo
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/repository#deactivate
 func (rs *RepositoriesService) Deactivate(ctx context.Context, slug string) (*Repository, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/deactivate", url.QueryEscape(slug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/deactivate", url.QueryEscape(slug)), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -230,7 +230,7 @@ func (rs *RepositoriesService) Deactivate(ctx context.Context, slug string) (*Re
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/repository#migrate
 func (rs *RepositoriesService) Migrate(ctx context.Context, slug string) (*Repository, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/migrate", url.QueryEscape(slug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/migrate", url.QueryEscape(slug)), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -253,7 +253,7 @@ func (rs *RepositoriesService) Migrate(ctx context.Context, slug string) (*Repos
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/repository#star
 func (rs *RepositoriesService) Star(ctx context.Context, slug string) (*Repository, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/star", url.QueryEscape(slug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/star", url.QueryEscape(slug)), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -276,7 +276,7 @@ func (rs *RepositoriesService) Star(ctx context.Context, slug string) (*Reposito
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/repository#unstar
 func (rs *RepositoriesService) Unstar(ctx context.Context, slug string) (*Repository, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/unstar", url.QueryEscape(slug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/unstar", url.QueryEscape(slug)), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/requests.go
+++ b/requests.go
@@ -91,7 +91,7 @@ type requestsResponse struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/request#find
 func (rs *RequestsService) FindByRepoId(ctx context.Context, repoId uint, id uint, opt *RequestOption) (*Request, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/request/%d", repoId, id), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/request/%d", repoId, id), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -114,7 +114,7 @@ func (rs *RequestsService) FindByRepoId(ctx context.Context, repoId uint, id uin
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/request#find
 func (rs *RequestsService) FindByRepoSlug(ctx context.Context, repoSlug string, id uint, opt *RequestOption) (*Request, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/request/%d", url.QueryEscape(repoSlug), id), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/request/%d", url.QueryEscape(repoSlug), id), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -173,7 +173,7 @@ type createRequestResponse struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/requests#find
 func (rs *RequestsService) ListByRepoId(ctx context.Context, repoId uint, opt *RequestsOption) ([]*Request, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/requests", repoId), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/requests", repoId), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -196,7 +196,7 @@ func (rs *RequestsService) ListByRepoId(ctx context.Context, repoId uint, opt *R
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/requests#find
 func (rs *RequestsService) ListByRepoSlug(ctx context.Context, repoSlug string, opt *RequestsOption) ([]*Request, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/requests", url.QueryEscape(repoSlug)), opt)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/requests", url.QueryEscape(repoSlug)), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -219,7 +219,7 @@ func (rs *RequestsService) ListByRepoSlug(ctx context.Context, repoSlug string, 
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/requests#create
 func (rs *RequestsService) CreateByRepoId(ctx context.Context, repoId uint, request *RequestBody) (*Request, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/requests", repoId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/requests", repoId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -242,7 +242,7 @@ func (rs *RequestsService) CreateByRepoId(ctx context.Context, repoId uint, requ
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/requests#create
 func (rs *RequestsService) CreateByRepoSlug(ctx context.Context, repoSlug string, request *RequestBody) (*Request, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/requests", url.QueryEscape(repoSlug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/requests", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/settings.go
+++ b/settings.go
@@ -60,7 +60,7 @@ const (
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/setting#find
 func (ss *SettingsService) FindByRepoId(ctx context.Context, repoId uint, name string) (*Setting, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/setting/%s", repoId, name), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/setting/%s", repoId, name), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -83,7 +83,7 @@ func (ss *SettingsService) FindByRepoId(ctx context.Context, repoId uint, name s
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/setting#find
 func (ss *SettingsService) FindByRepoSlug(ctx context.Context, repoSlug string, name string) (*Setting, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/setting/%s", url.QueryEscape(repoSlug), name), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/setting/%s", url.QueryEscape(repoSlug), name), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -106,7 +106,7 @@ func (ss *SettingsService) FindByRepoSlug(ctx context.Context, repoSlug string, 
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/settings#for_repository
 func (ss *SettingsService) ListByRepoId(ctx context.Context, repoId uint) ([]*Setting, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/settings", repoId), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/settings", repoId), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -129,7 +129,7 @@ func (ss *SettingsService) ListByRepoId(ctx context.Context, repoId uint) ([]*Se
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/settings#for_repository
 func (ss *SettingsService) ListByRepoSlug(ctx context.Context, repoSlug string) ([]*Setting, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/settings", url.QueryEscape(repoSlug)), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/settings", url.QueryEscape(repoSlug)), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -152,7 +152,7 @@ func (ss *SettingsService) ListByRepoSlug(ctx context.Context, repoSlug string) 
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/setting#update
 func (ss *SettingsService) UpdateByRepoId(ctx context.Context, repoId uint, setting *SettingBody) (*Setting, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%d/setting/%s", repoId, setting.Name), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%d/setting/%s", repoId, setting.Name), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -181,7 +181,7 @@ func (ss *SettingsService) UpdateByRepoId(ctx context.Context, repoId uint, sett
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/setting#update
 func (ss *SettingsService) UpdateByRepoSlug(ctx context.Context, repoSlug string, setting *SettingBody) (*Setting, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/repo/%s/setting/%s", url.QueryEscape(repoSlug), setting.Name), nil)
+	u, err := urlWithOptions(fmt.Sprintf("repo/%s/setting/%s", url.QueryEscape(repoSlug), setting.Name), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/stages.go
+++ b/stages.go
@@ -52,7 +52,7 @@ type stagesResponse struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/stages#find
 func (ss *StagesService) ListByBuild(ctx context.Context, buildId uint, opt *StagesOption) ([]*Stage, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/build/%d/stages", buildId), opt)
+	u, err := urlWithOptions(fmt.Sprintf("build/%d/stages", buildId), opt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/users.go
+++ b/users.go
@@ -56,7 +56,7 @@ type UserOption struct {
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/user#current
 func (us *UserService) Current(ctx context.Context, opt *UserOption) (*User, *http.Response, error) {
-	u, err := urlWithOptions("/user", opt)
+	u, err := urlWithOptions("user", opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -79,7 +79,7 @@ func (us *UserService) Current(ctx context.Context, opt *UserOption) (*User, *ht
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/user#find
 func (us *UserService) Find(ctx context.Context, id uint, opt *UserOption) (*User, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/user/%d", id), opt)
+	u, err := urlWithOptions(fmt.Sprintf("user/%d", id), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -103,7 +103,7 @@ func (us *UserService) Find(ctx context.Context, id uint, opt *UserOption) (*Use
 //
 // Travis CI API docs: https://developer.travis-ci.com/resource/user#sync
 func (us *UserService) Sync(ctx context.Context, id uint) (*User, *http.Response, error) {
-	u, err := urlWithOptions(fmt.Sprintf("/user/%d/sync", id), nil)
+	u, err := urlWithOptions(fmt.Sprintf("user/%d/sync", id), nil)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Removed the `/` from the start of all the API paths.

Enterprise API is at `https://<domain>/api/`, the prefix slash removes the `/api/` and means the library doesn't work with Travis CI Enterprise.

Also, thanks for the awesome library !