### PR TITLE
Fix build duration type

### DIFF
--- a/active_test.go
+++ b/active_test.go
@@ -33,7 +33,7 @@ func TestActiveService_FindByOwner(t *testing.T) {
 		t.Errorf("Active.FindByOwner returned error: %v", err)
 	}
 
-	want := []*Build{{Id: Uint(testBuildId), Number: String("1"), State: String(BuildStateCreated), Duration: Uint(10)}}
+	want := []*Build{{Id: Uint(testBuildId), Number: String("1"), State: String(BuildStateCreated), Duration: Int64(10)}}
 	if !reflect.DeepEqual(builds, want) {
 		t.Errorf("Active.FindByOwner returned %+v, want %+v", builds, want)
 	}
@@ -56,7 +56,7 @@ func TestActiveService_FindByGitHubId(t *testing.T) {
 		t.Errorf("Active.FindByGitHubId returned error: %v", err)
 	}
 
-	want := []*Build{{Id: Uint(testBuildId), Number: String("1"), State: String(BuildStateCreated), Duration: Uint(10)}}
+	want := []*Build{{Id: Uint(testBuildId), Number: String("1"), State: String(BuildStateCreated), Duration: Int64(10)}}
 	if !reflect.DeepEqual(builds, want) {
 		t.Errorf("Active.FindByGitHubId returned %+v, want %+v", builds, want)
 	}

--- a/builds.go
+++ b/builds.go
@@ -29,7 +29,7 @@ type Build struct {
 	// Current state of the build
 	State *string `json:"state,omitempty"`
 	// Wall clock time in seconds
-	Duration *uint `json:"duration,omitempty"`
+	Duration *int64 `json:"duration,omitempty"`
 	// Event that triggered the build
 	EventType *string `json:"event_type,omitempty"`
 	// State of the previous build (useful to see if state changed)

--- a/builds_integration_test.go
+++ b/builds_integration_test.go
@@ -26,7 +26,7 @@ func TestBuildService_Integration_Find(t *testing.T) {
 	}
 
 	if *build.Id != integrationBuildId {
-		t.Fatalf("unexpected job returned: want job id %d: got job id %d", integrationBuildId, build.Id)
+		t.Fatalf("unexpected build returned: want build id %d: got build id %d", integrationBuildId, build.Id)
 	}
 }
 

--- a/builds_test.go
+++ b/builds_test.go
@@ -31,7 +31,7 @@ func TestBuildsService_Find(t *testing.T) {
 		t.Errorf("Build.Find returned error: %v", err)
 	}
 
-	want := &Build{Id: Uint(testBuildId), Number: String("1"), State: String(BuildStateCreated), Duration: Uint(10)}
+	want := &Build{Id: Uint(testBuildId), Number: String("1"), State: String(BuildStateCreated), Duration: Int64(10)}
 	if !reflect.DeepEqual(build, want) {
 		t.Errorf("Build.Find returned %+v, want %+v", build, want)
 	}
@@ -53,7 +53,7 @@ func TestBuildsService_List(t *testing.T) {
 		t.Errorf("Builds.Find returned error: %v", err)
 	}
 
-	want := []*Build{{Id: Uint(testBuildId), Number: String("1"), State: String(BuildStateCreated), Duration: Uint(10)}}
+	want := []*Build{{Id: Uint(testBuildId), Number: String("1"), State: String(BuildStateCreated), Duration: Int64(10)}}
 	if !reflect.DeepEqual(builds, want) {
 		t.Errorf("Builds.Find returned %+v, want %+v", builds, want)
 	}
@@ -75,7 +75,7 @@ func TestBuildsService_ListByRepoId(t *testing.T) {
 		t.Errorf("Builds.FindByRepoId returned error: %v", err)
 	}
 
-	want := []*Build{{Id: Uint(testBuildId), Number: String("1"), State: String(BuildStateCreated), Duration: Uint(10)}}
+	want := []*Build{{Id: Uint(testBuildId), Number: String("1"), State: String(BuildStateCreated), Duration: Int64(10)}}
 	if !reflect.DeepEqual(builds, want) {
 		t.Errorf("Builds.FindByRepoId returned %+v, want %+v", builds, want)
 	}
@@ -97,7 +97,7 @@ func TestBuildsService_ListByRepoSlug(t *testing.T) {
 		t.Errorf("Builds.FindByRepoSlug returned error: %v", err)
 	}
 
-	want := []*Build{{Id: Uint(testBuildId), Number: String("1"), State: String(BuildStateCreated), Duration: Uint(10)}}
+	want := []*Build{{Id: Uint(testBuildId), Number: String("1"), State: String(BuildStateCreated), Duration: Int64(10)}}
 	if !reflect.DeepEqual(builds, want) {
 		t.Errorf("Builds.FindByRepoSlug returned %+v, want %+v", builds, want)
 	}
@@ -118,7 +118,7 @@ func TestBuildsService_Cancel(t *testing.T) {
 		t.Errorf("Build.Cancel returned error: %v", err)
 	}
 
-	want := &Build{Id: Uint(testBuildId), Number: String("1"), State: String(BuildStateCreated), Duration: Uint(10)}
+	want := &Build{Id: Uint(testBuildId), Number: String("1"), State: String(BuildStateCreated), Duration: Int64(10)}
 	if !reflect.DeepEqual(build, want) {
 		t.Errorf("Build.Cancel returned %+v, want %+v", build, want)
 	}
@@ -139,7 +139,7 @@ func TestBuildsService_Restart(t *testing.T) {
 		t.Errorf("Build.Restart returned error: %v", err)
 	}
 
-	want := &Build{Id: Uint(testBuildId), Number: String("1"), State: String(BuildStateCreated), Duration: Uint(10)}
+	want := &Build{Id: Uint(testBuildId), Number: String("1"), State: String(BuildStateCreated), Duration: Int64(10)}
 	if !reflect.DeepEqual(build, want) {
 		t.Errorf("Build.Restart returned %+v, want %+v", build, want)
 	}

--- a/init_integration_test.go
+++ b/init_integration_test.go
@@ -9,10 +9,11 @@ package travis
 
 import (
 	"os"
+	"strconv"
 )
 
 var (
-	integrationBuildId       uint = 426024083
+	integrationBuildId       uint
 	integrationClient        *Client
 	integrationGitHubOwner        = "shuheiktgwtest"
 	integrationGitHubOwnerId uint = 41975784
@@ -32,4 +33,14 @@ func init() {
 	}
 
 	integrationClient = NewClient(integrationUrl, integrationTravisToken)
+	integrationBuildId = toUint(os.Getenv("TRAVIS_INTEGRATION_BUILD_ID"))
+}
+
+func toUint(s string) uint {
+	i ,err := strconv.Atoi(s)
+	if err != nil {
+		panic(err)
+	}
+
+	return uint(i)
 }

--- a/travis.go
+++ b/travis.go
@@ -325,6 +325,10 @@ func Bool(v bool) *bool { return &v }
 // to store v and returns a pointer to it.
 func Uint(v uint) *uint { return &v }
 
+// Int64 is a helper routine that allocates a new Int64 value
+// to store v and returns a pointer to it.
+func Int64(v int64) *int64 { return &v }
+
 // String is a helper routine that allocates a new string value
 // to store v and returns a pointer to it.
 func String(v string) *string { return &v }


### PR DESCRIPTION
Fix https://github.com/shuheiktgw/go-travis/issues/70. Apparently, `build`'s duration can be negative, so change its type from uint to int64.